### PR TITLE
Add API contract and OpenAPI documentation

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -128,6 +128,11 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-redis</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <version>2.8.6</version>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/backend/src/main/java/com/fairtix/analytics/api/AnalyticsController.java
+++ b/backend/src/main/java/com/fairtix/analytics/api/AnalyticsController.java
@@ -1,24 +1,45 @@
 package com.fairtix.analytics.api;
 
 import com.fairtix.analytics.application.AnalyticsService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * Provides aggregate analytics for the admin dashboard.
+ *
+ * <p>Returns event counts, seat utilisation, hold metrics, and user breakdowns
+ * in a single response to minimise round-trips.
+ */
+@Tag(name = "Analytics", description = "Admin dashboard analytics")
 @RestController
 @RequestMapping("/api/analytics")
 public class AnalyticsController {
 
-  private final AnalyticsService analyticsService;
+    private final AnalyticsService analyticsService;
 
-  public AnalyticsController(AnalyticsService analyticsService) {
-    this.analyticsService = analyticsService;
-  }
+    public AnalyticsController(AnalyticsService analyticsService) {
+        this.analyticsService = analyticsService;
+    }
 
-  @PreAuthorize("hasRole('ADMIN')")
-  @GetMapping("/dashboard")
-  public AnalyticsResponse getDashboardAnalytics() {
-    return analyticsService.getDashboardAnalytics();
-  }
+    /**
+     * Returns a comprehensive analytics snapshot for the admin dashboard.
+     *
+     * @return aggregate stats covering events, seats, holds, and users
+     */
+    @Operation(summary = "Get dashboard analytics",
+            description = "Admin-only. Returns aggregate statistics for the admin dashboard.")
+    @ApiResponse(responseCode = "200", description = "Analytics snapshot")
+    @ApiResponse(responseCode = "403", description = "Not an admin")
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/dashboard")
+    public AnalyticsResponse getDashboardAnalytics() {
+        return analyticsService.getDashboardAnalytics();
+    }
 }

--- a/backend/src/main/java/com/fairtix/analytics/api/AnalyticsController.java
+++ b/backend/src/main/java/com/fairtix/analytics/api/AnalyticsController.java
@@ -1,0 +1,24 @@
+package com.fairtix.analytics.api;
+
+import com.fairtix.analytics.application.AnalyticsService;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/analytics")
+public class AnalyticsController {
+
+  private final AnalyticsService analyticsService;
+
+  public AnalyticsController(AnalyticsService analyticsService) {
+    this.analyticsService = analyticsService;
+  }
+
+  @PreAuthorize("hasRole('ADMIN')")
+  @GetMapping("/dashboard")
+  public AnalyticsResponse getDashboardAnalytics() {
+    return analyticsService.getDashboardAnalytics();
+  }
+}

--- a/backend/src/main/java/com/fairtix/analytics/api/AnalyticsResponse.java
+++ b/backend/src/main/java/com/fairtix/analytics/api/AnalyticsResponse.java
@@ -13,7 +13,7 @@ public record AnalyticsResponse(
         Map<String, Long> seatsByStatus,
         List<EventInventory> topEventsByBookings,
         Map<String, Long> holdsByStatus,
-        @Schema(description = "Ratio of confirmed holds to total holds", example = "0.75")
+        @Schema(description = "Hold confirmation rate as a percentage (0-100)", example = "75.0")
         double holdConfirmationRate,
         List<DailyHoldCount> holdsPerDay,
         Map<String, Long> usersByRole) {

--- a/backend/src/main/java/com/fairtix/analytics/api/AnalyticsResponse.java
+++ b/backend/src/main/java/com/fairtix/analytics/api/AnalyticsResponse.java
@@ -1,32 +1,51 @@
 package com.fairtix.analytics.api;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+@Schema(description = "Aggregate analytics snapshot for the admin dashboard")
 public record AnalyticsResponse(
-    OverviewStats overview,
-    List<VenueCount> eventsByVenue,
-    Map<String, Long> seatsByStatus,
-    List<EventInventory> topEventsByBookings,
-    Map<String, Long> holdsByStatus,
-    double holdConfirmationRate,
-    List<DailyHoldCount> holdsPerDay,
-    Map<String, Long> usersByRole
-) {
+        OverviewStats overview,
+        List<VenueCount> eventsByVenue,
+        Map<String, Long> seatsByStatus,
+        List<EventInventory> topEventsByBookings,
+        Map<String, Long> holdsByStatus,
+        @Schema(description = "Ratio of confirmed holds to total holds", example = "0.75")
+        double holdConfirmationRate,
+        List<DailyHoldCount> holdsPerDay,
+        Map<String, Long> usersByRole) {
 
-  public record OverviewStats(
-      long totalEvents,
-      long upcomingEvents,
-      long totalUsers,
-      long totalSeats,
-      long bookedSeats,
-      long activeHolds
-  ) {}
+    @Schema(description = "High-level platform statistics")
+    public record OverviewStats(
+            @Schema(example = "42") long totalEvents,
+            @Schema(example = "18") long upcomingEvents,
+            @Schema(example = "350") long totalUsers,
+            @Schema(example = "5000") long totalSeats,
+            @Schema(example = "1200") long bookedSeats,
+            @Schema(example = "85") long activeHolds) {
+    }
 
-  public record VenueCount(String venue, long count) {}
+    @Schema(description = "Event count grouped by venue")
+    public record VenueCount(
+            @Schema(example = "Madison Square Garden") String venue,
+            @Schema(example = "12") long count) {
+    }
 
-  public record EventInventory(UUID eventId, String eventTitle, long available, long held, long booked) {}
+    @Schema(description = "Seat inventory breakdown for a single event")
+    public record EventInventory(
+            UUID eventId,
+            @Schema(example = "Summer Music Festival") String eventTitle,
+            @Schema(example = "200") long available,
+            @Schema(example = "50") long held,
+            @Schema(example = "150") long booked) {
+    }
 
-  public record DailyHoldCount(String date, long count) {}
+    @Schema(description = "Hold count for a single day")
+    public record DailyHoldCount(
+            @Schema(example = "2026-03-25") String date,
+            @Schema(example = "34") long count) {
+    }
 }

--- a/backend/src/main/java/com/fairtix/analytics/api/AnalyticsResponse.java
+++ b/backend/src/main/java/com/fairtix/analytics/api/AnalyticsResponse.java
@@ -1,0 +1,32 @@
+package com.fairtix.analytics.api;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public record AnalyticsResponse(
+    OverviewStats overview,
+    List<VenueCount> eventsByVenue,
+    Map<String, Long> seatsByStatus,
+    List<EventInventory> topEventsByBookings,
+    Map<String, Long> holdsByStatus,
+    double holdConfirmationRate,
+    List<DailyHoldCount> holdsPerDay,
+    Map<String, Long> usersByRole
+) {
+
+  public record OverviewStats(
+      long totalEvents,
+      long upcomingEvents,
+      long totalUsers,
+      long totalSeats,
+      long bookedSeats,
+      long activeHolds
+  ) {}
+
+  public record VenueCount(String venue, long count) {}
+
+  public record EventInventory(UUID eventId, String eventTitle, long available, long held, long booked) {}
+
+  public record DailyHoldCount(String date, long count) {}
+}

--- a/backend/src/main/java/com/fairtix/analytics/application/AnalyticsService.java
+++ b/backend/src/main/java/com/fairtix/analytics/application/AnalyticsService.java
@@ -1,0 +1,153 @@
+package com.fairtix.analytics.application;
+
+import com.fairtix.analytics.api.AnalyticsResponse;
+import com.fairtix.analytics.api.AnalyticsResponse.DailyHoldCount;
+import com.fairtix.analytics.api.AnalyticsResponse.EventInventory;
+import com.fairtix.analytics.api.AnalyticsResponse.OverviewStats;
+import com.fairtix.analytics.api.AnalyticsResponse.VenueCount;
+import com.fairtix.events.infrastructure.EventRepository;
+import com.fairtix.inventory.domain.HoldStatus;
+import com.fairtix.inventory.domain.SeatStatus;
+import com.fairtix.inventory.infrastructure.SeatHoldRepository;
+import com.fairtix.inventory.infrastructure.SeatRepository;
+import com.fairtix.users.infrastructure.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+
+@Service
+@Transactional(readOnly = true)
+public class AnalyticsService {
+
+  private final EventRepository eventRepository;
+  private final SeatRepository seatRepository;
+  private final SeatHoldRepository seatHoldRepository;
+  private final UserRepository userRepository;
+
+  public AnalyticsService(EventRepository eventRepository,
+                          SeatRepository seatRepository,
+                          SeatHoldRepository seatHoldRepository,
+                          UserRepository userRepository) {
+    this.eventRepository = eventRepository;
+    this.seatRepository = seatRepository;
+    this.seatHoldRepository = seatHoldRepository;
+    this.userRepository = userRepository;
+  }
+
+  public AnalyticsResponse getDashboardAnalytics() {
+    OverviewStats overview = buildOverview();
+    List<VenueCount> eventsByVenue = buildEventsByVenue();
+    Map<String, Long> seatsByStatus = buildSeatsByStatus();
+    List<EventInventory> topEvents = buildTopEventsByBookings();
+    Map<String, Long> holdsByStatus = buildHoldsByStatus();
+    double holdConfirmationRate = computeHoldConfirmationRate(holdsByStatus);
+    List<DailyHoldCount> holdsPerDay = buildHoldsPerDay();
+    Map<String, Long> usersByRole = buildUsersByRole();
+
+    return new AnalyticsResponse(
+        overview, eventsByVenue, seatsByStatus, topEvents,
+        holdsByStatus, holdConfirmationRate, holdsPerDay, usersByRole
+    );
+  }
+
+  private OverviewStats buildOverview() {
+    long totalEvents = eventRepository.count();
+    long upcomingEvents = eventRepository.countByStartTimeAfter(Instant.now());
+    long totalUsers = userRepository.count();
+    long totalSeats = seatRepository.count();
+
+    Map<String, Long> seatCounts = buildSeatsByStatus();
+    long bookedSeats = seatCounts.getOrDefault("BOOKED", 0L);
+    long activeHolds = seatCounts.getOrDefault("HELD", 0L);
+
+    return new OverviewStats(totalEvents, upcomingEvents, totalUsers, totalSeats, bookedSeats, activeHolds);
+  }
+
+  private List<VenueCount> buildEventsByVenue() {
+    return eventRepository.countByVenueGrouped().stream()
+        .map(row -> new VenueCount((String) row[0], (Long) row[1]))
+        .sorted(Comparator.comparingLong(VenueCount::count).reversed())
+        .toList();
+  }
+
+  private Map<String, Long> buildSeatsByStatus() {
+    Map<String, Long> map = new LinkedHashMap<>();
+    for (SeatStatus status : SeatStatus.values()) {
+      map.put(status.name(), 0L);
+    }
+    for (Object[] row : seatRepository.countByStatusGrouped()) {
+      map.put(((SeatStatus) row[0]).name(), (Long) row[1]);
+    }
+    return map;
+  }
+
+  private List<EventInventory> buildTopEventsByBookings() {
+    Map<UUID, String> titleById = new HashMap<>();
+    Map<UUID, Map<String, Long>> statusCounts = new HashMap<>();
+
+    for (Object[] row : seatRepository.countByEventAndStatus()) {
+      UUID eventId = (UUID) row[0];
+      String title = (String) row[1];
+      SeatStatus status = (SeatStatus) row[2];
+      long count = (Long) row[3];
+
+      titleById.put(eventId, title);
+      statusCounts.computeIfAbsent(eventId, k -> new HashMap<>())
+          .put(status.name(), count);
+    }
+
+    return statusCounts.entrySet().stream()
+        .map(e -> {
+          UUID id = e.getKey();
+          Map<String, Long> counts = e.getValue();
+          return new EventInventory(
+              id,
+              titleById.get(id),
+              counts.getOrDefault("AVAILABLE", 0L),
+              counts.getOrDefault("HELD", 0L),
+              counts.getOrDefault("BOOKED", 0L)
+          );
+        })
+        .sorted(Comparator.comparingLong(EventInventory::booked).reversed())
+        .limit(10)
+        .toList();
+  }
+
+  private Map<String, Long> buildHoldsByStatus() {
+    Map<String, Long> map = new LinkedHashMap<>();
+    for (HoldStatus status : HoldStatus.values()) {
+      map.put(status.name(), 0L);
+    }
+    for (Object[] row : seatHoldRepository.countByStatusGrouped()) {
+      map.put(((HoldStatus) row[0]).name(), (Long) row[1]);
+    }
+    return map;
+  }
+
+  private double computeHoldConfirmationRate(Map<String, Long> holdsByStatus) {
+    long confirmed = holdsByStatus.getOrDefault("CONFIRMED", 0L);
+    long expired = holdsByStatus.getOrDefault("EXPIRED", 0L);
+    long released = holdsByStatus.getOrDefault("RELEASED", 0L);
+    long completed = confirmed + expired + released;
+    if (completed == 0) return 0.0;
+    return Math.round((double) confirmed / completed * 1000.0) / 10.0;
+  }
+
+  private List<DailyHoldCount> buildHoldsPerDay() {
+    Instant since = Instant.now().minus(30, ChronoUnit.DAYS);
+    return seatHoldRepository.countHoldsPerDay(since).stream()
+        .map(row -> new DailyHoldCount(row[0].toString(), ((Number) row[1]).longValue()))
+        .toList();
+  }
+
+  private Map<String, Long> buildUsersByRole() {
+    Map<String, Long> map = new LinkedHashMap<>();
+    for (Object[] row : userRepository.countByRoleGrouped()) {
+      map.put(row[0].toString(), (Long) row[1]);
+    }
+    return map;
+  }
+}

--- a/backend/src/main/java/com/fairtix/analytics/application/AnalyticsService.java
+++ b/backend/src/main/java/com/fairtix/analytics/application/AnalyticsService.java
@@ -16,7 +16,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 @Service
 @Transactional(readOnly = true)
@@ -38,9 +43,9 @@ public class AnalyticsService {
   }
 
   public AnalyticsResponse getDashboardAnalytics() {
-    OverviewStats overview = buildOverview();
-    List<VenueCount> eventsByVenue = buildEventsByVenue();
     Map<String, Long> seatsByStatus = buildSeatsByStatus();
+    OverviewStats overview = buildOverview(seatsByStatus);
+    List<VenueCount> eventsByVenue = buildEventsByVenue();
     List<EventInventory> topEvents = buildTopEventsByBookings();
     Map<String, Long> holdsByStatus = buildHoldsByStatus();
     double holdConfirmationRate = computeHoldConfirmationRate(holdsByStatus);
@@ -53,15 +58,14 @@ public class AnalyticsService {
     );
   }
 
-  private OverviewStats buildOverview() {
+  private OverviewStats buildOverview(Map<String, Long> seatsByStatus) {
     long totalEvents = eventRepository.count();
     long upcomingEvents = eventRepository.countByStartTimeAfter(Instant.now());
     long totalUsers = userRepository.count();
     long totalSeats = seatRepository.count();
 
-    Map<String, Long> seatCounts = buildSeatsByStatus();
-    long bookedSeats = seatCounts.getOrDefault("BOOKED", 0L);
-    long activeHolds = seatCounts.getOrDefault("HELD", 0L);
+    long bookedSeats = seatsByStatus.getOrDefault("BOOKED", 0L);
+    long activeHolds = seatsByStatus.getOrDefault("HELD", 0L);
 
     return new OverviewStats(totalEvents, upcomingEvents, totalUsers, totalSeats, bookedSeats, activeHolds);
   }

--- a/backend/src/main/java/com/fairtix/auth/api/AuthController.java
+++ b/backend/src/main/java/com/fairtix/auth/api/AuthController.java
@@ -1,33 +1,65 @@
 package com.fairtix.auth.api;
 
-import java.util.Map;
-
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.fairtix.auth.application.AuthService;
+import com.fairtix.users.dto.AuthResponse;
 import com.fairtix.users.dto.LoginRequest;
 import com.fairtix.users.dto.RegisterRequest;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * Handles user authentication — registration and login.
+ *
+ * <p>All endpoints are public and return a signed JWT on success.
+ */
+@Tag(name = "Auth", description = "Registration and login")
 @RestController
 @RequestMapping("/auth")
 public class AuthController {
 
-  private final AuthService service;
+    private final AuthService service;
 
-  public AuthController(AuthService service) {
-    this.service = service;
-  }
+    public AuthController(AuthService service) {
+        this.service = service;
+    }
 
-  @PostMapping("/register")
-  public Map<String, String> register(@RequestBody RegisterRequest request) {
-    return Map.of("token", service.register(request));
-  }
+    /**
+     * Registers a new user account.
+     *
+     * @param request email and password for the new account
+     * @return a signed JWT for the newly created user
+     */
+    @Operation(summary = "Register a new user",
+            description = "Creates a user account and returns a JWT token.")
+    @ApiResponse(responseCode = "200", description = "Registration successful")
+    @ApiResponse(responseCode = "409", description = "Email already in use")
+    @SecurityRequirements
+    @PostMapping("/register")
+    public AuthResponse register(@RequestBody RegisterRequest request) {
+        return new AuthResponse(service.register(request));
+    }
 
-  @PostMapping("/login")
-  public Map<String, String> login(@RequestBody LoginRequest request) {
-    return Map.of("token", service.login(request));
-  }
+    /**
+     * Authenticates an existing user.
+     *
+     * @param request email and password credentials
+     * @return a signed JWT for the authenticated user
+     */
+    @Operation(summary = "Log in",
+            description = "Authenticates with email/password and returns a JWT token.")
+    @ApiResponse(responseCode = "200", description = "Login successful")
+    @ApiResponse(responseCode = "401", description = "Invalid credentials")
+    @SecurityRequirements
+    @PostMapping("/login")
+    public AuthResponse login(@RequestBody LoginRequest request) {
+        return new AuthResponse(service.login(request));
+    }
 }

--- a/backend/src/main/java/com/fairtix/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/fairtix/config/OpenApiConfig.java
@@ -1,0 +1,32 @@
+package com.fairtix.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI fairtixOpenAPI() {
+        String schemeName = "bearerAuth";
+        return new OpenAPI()
+                .info(new Info()
+                        .title("FairTix API")
+                        .version("1.0.0")
+                        .description("Fair ticketing platform API for event management, "
+                                + "seat inventory, holds, and administration."))
+                .addSecurityItem(new SecurityRequirement().addList(schemeName))
+                .components(new Components()
+                        .addSecuritySchemes(schemeName, new SecurityScheme()
+                                .name(schemeName)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .description("Paste a JWT obtained from POST /auth/login")));
+    }
+}

--- a/backend/src/main/java/com/fairtix/config/RedisConfig.java
+++ b/backend/src/main/java/com/fairtix/config/RedisConfig.java
@@ -4,6 +4,7 @@ import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -17,6 +18,7 @@ public class RedisConfig {
     private int redisPort;
 
     @Bean
+    @ConditionalOnMissingBean(RedissonClient.class)
     public RedissonClient redissonClient() {
         Config config = new Config();
         config.useSingleServer()

--- a/backend/src/main/java/com/fairtix/config/RedisConfig.java
+++ b/backend/src/main/java/com/fairtix/config/RedisConfig.java
@@ -3,17 +3,24 @@ package com.fairtix.config;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class RedisConfig {
 
+    @Value("${spring.redis.host:localhost}")
+    private String redisHost;
+
+    @Value("${spring.redis.port:6379}")
+    private int redisPort;
+
     @Bean
     public RedissonClient redissonClient() {
         Config config = new Config();
         config.useSingleServer()
-              .setAddress("redis://127.0.0.1:6379");
+              .setAddress("redis://" + redisHost + ":" + redisPort);
 
         return Redisson.create(config);
     }

--- a/backend/src/main/java/com/fairtix/config/SecurityConfig.java
+++ b/backend/src/main/java/com/fairtix/config/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
         .csrf(csrf -> csrf.disable())
         .authorizeHttpRequests(auth -> auth
             .requestMatchers("/auth/**").permitAll()
+            .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
             .requestMatchers(HttpMethod.GET, "/api/events/**").permitAll()
             .anyRequest().authenticated())
         .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/backend/src/main/java/com/fairtix/config/SecurityConfig.java
+++ b/backend/src/main/java/com/fairtix/config/SecurityConfig.java
@@ -18,7 +18,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 
-@EnableMethodSecurity
+@EnableMethodSecurity(jsr250Enabled = true)
 @Configuration
 public class SecurityConfig {
 

--- a/backend/src/main/java/com/fairtix/events/api/EventController.java
+++ b/backend/src/main/java/com/fairtix/events/api/EventController.java
@@ -12,103 +12,133 @@ import com.fairtix.events.dto.CreateEventRequest;
 import com.fairtix.events.dto.UpdateEventRequest;
 import com.fairtix.events.dto.EventResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.security.PermitAll;
 import jakarta.validation.Valid;
 
 import java.util.UUID;
 
+/**
+ * CRUD operations for events.
+ *
+ * <p>Read endpoints are public; create, update, and delete require the ADMIN role.
+ */
+@Tag(name = "Events", description = "Event management")
 @RestController
 @RequestMapping("/api/events")
 public class EventController {
 
-  private final EventService service;
+    private final EventService service;
 
-  public EventController(EventService service) {
-    this.service = service;
-  }
+    public EventController(EventService service) {
+        this.service = service;
+    }
 
-  /**
-   * Creates a new event.
-   *
-   * Accepts a JSON request body containing event details
-   * 
-   * @param request the requested event as a json payload
-   * @return the newly created event
-   */
-  @PreAuthorize("hasRole('ADMIN')")
-  @PostMapping
-  @ResponseStatus(HttpStatus.CREATED)
-  public EventResponse createEvent(@Valid @RequestBody CreateEventRequest request) {
-    Event event = service.createEvent(
-        request.title(),
-        request.startTime(),
-        request.venue());
-    return EventResponse.from(event);
-  }
+    /**
+     * Creates a new event.
+     *
+     * Accepts a JSON request body containing event details
+     *
+     * @param request the requested event as a json payload
+     * @return the newly created event
+     */
+    @Operation(summary = "Create an event", description = "Admin-only. Creates a new event.")
+    @ApiResponse(responseCode = "201", description = "Event created")
+    @ApiResponse(responseCode = "400", description = "Validation error")
+    @ApiResponse(responseCode = "403", description = "Not an admin")
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public EventResponse createEvent(@Valid @RequestBody CreateEventRequest request) {
+        Event event = service.createEvent(
+                request.title(),
+                request.startTime(),
+                request.venue());
+        return EventResponse.from(event);
+    }
 
-  /**
-   * Takes details about the types of events requested and returns a page of that
-   * type of event
-   *
-   * @param venueName the name of the venue
-   * @param title     the title of the event
-   * @param upcoming  whether or not to only display upcoming events
-   *                  (true by default)
-   * @param page      the page number
-   * @param size      the number of items per page
-   * @return the requested page
-   */
-  @PermitAll
-  @GetMapping
-  public Page<EventResponse> search(
-      @RequestParam(required = false) String venueName,
-      @RequestParam(required = false) String title,
-      @RequestParam(required = false) Boolean upcoming,
-      @RequestParam(defaultValue = "0") int page,
-      @RequestParam(defaultValue = "20") int size) {
+    /**
+     * Takes details about the types of events requested and returns a page of that
+     * type of event
+     *
+     * @param venueName the name of the venue
+     * @param title     the title of the event
+     * @param upcoming  whether or not to only display upcoming events
+     *                  (true by default)
+     * @param page      the page number
+     * @param size      the number of items per page
+     * @return the requested page
+     */
+    @Operation(summary = "Search events",
+            description = "Public. Returns a paginated list of events, optionally filtered.")
+    @ApiResponse(responseCode = "200", description = "Page of matching events")
+    @SecurityRequirements
+    @PermitAll
+    @GetMapping
+    public Page<EventResponse> search(
+            @Parameter(description = "Filter by venue name") @RequestParam(required = false) String venueName,
+            @Parameter(description = "Filter by title (contains)") @RequestParam(required = false) String title,
+            @Parameter(description = "Only future events") @RequestParam(required = false) Boolean upcoming,
+            @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size (max 100)") @RequestParam(defaultValue = "20") int size) {
 
-    Page<Event> events = service.search(venueName, title, upcoming, PageRequest.of(page, Math.min(size, 100)));
-    return events.map(EventResponse::from);
-  }
+        Page<Event> events = service.search(venueName, title, upcoming, PageRequest.of(page, Math.min(size, 100)));
+        return events.map(EventResponse::from);
+    }
 
-  /**
-   * Gets a specific event based on its id
-   *
-   * @param id the id of the event
-   * @return the requested event
-   */
-  @PermitAll
-  @GetMapping("/{id}")
-  public EventResponse getEvent(@PathVariable UUID id) {
-    return EventResponse.from(service.getEvent(id));
-  }
+    /**
+     * Gets a specific event based on its id
+     *
+     * @param id the id of the event
+     * @return the requested event
+     */
+    @Operation(summary = "Get event by ID", description = "Public. Returns a single event.")
+    @ApiResponse(responseCode = "200", description = "Event found")
+    @ApiResponse(responseCode = "404", description = "Event not found")
+    @SecurityRequirements
+    @PermitAll
+    @GetMapping("/{id}")
+    public EventResponse getEvent(@PathVariable UUID id) {
+        return EventResponse.from(service.getEvent(id));
+    }
 
-  /**
-   * Updates the title or start time of an event
-   *
-   * @param id      the id of the event
-   * @param request an {@link UpdateEventRequest} containing the updated details
-   *                of the event
-   * @return an {@link EventResponse} containing the newly updated event
-   */
-  @PreAuthorize("hasRole('ADMIN')")
-  @PutMapping("/{id}")
-  public EventResponse update(
-      @PathVariable UUID id,
-      @Valid @RequestBody UpdateEventRequest request) {
-    Event updated = service.update(id, request);
-    return EventResponse.from(updated);
-  }
+    /**
+     * Updates the title or start time of an event
+     *
+     * @param id      the id of the event
+     * @param request an {@link UpdateEventRequest} containing the updated details
+     *                of the event
+     * @return an {@link EventResponse} containing the newly updated event
+     */
+    @Operation(summary = "Update an event", description = "Admin-only. Updates title and/or start time.")
+    @ApiResponse(responseCode = "200", description = "Event updated")
+    @ApiResponse(responseCode = "400", description = "Validation error")
+    @ApiResponse(responseCode = "404", description = "Event not found")
+    @PreAuthorize("hasRole('ADMIN')")
+    @PutMapping("/{id}")
+    public EventResponse update(
+            @PathVariable UUID id,
+            @Valid @RequestBody UpdateEventRequest request) {
+        Event updated = service.update(id, request);
+        return EventResponse.from(updated);
+    }
 
-  /**
-   * Deletes the requested event
-   *
-   * @param id the UUID id of the event
-   */
-  @PreAuthorize("hasRole('ADMIN')")
-  @DeleteMapping("/{id}")
-  @ResponseStatus(HttpStatus.NO_CONTENT)
-  public void delete(@PathVariable UUID id) {
-    service.delete(id);
-  }
+    /**
+     * Deletes the requested event
+     *
+     * @param id the UUID id of the event
+     */
+    @Operation(summary = "Delete an event", description = "Admin-only. Permanently deletes an event.")
+    @ApiResponse(responseCode = "204", description = "Event deleted")
+    @ApiResponse(responseCode = "404", description = "Event not found")
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable UUID id) {
+        service.delete(id);
+    }
 }

--- a/backend/src/main/java/com/fairtix/events/dto/CreateEventRequest.java
+++ b/backend/src/main/java/com/fairtix/events/dto/CreateEventRequest.java
@@ -2,18 +2,23 @@ package com.fairtix.events.dto;
 
 import java.time.Instant;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 /**
  * Requests / Creates payload for creating a new event
- * 
+ *
  * @param title     the event title
  * @param startTime the event start time in UTC (ISO-8601)
  * @param venue     the venue name
  */
+@Schema(description = "Payload for creating a new event")
 public record CreateEventRequest(
-                @NotBlank String title,
-                @NotNull Instant startTime,
-                @NotBlank String venue) {
+        @Schema(description = "Event title", example = "Summer Music Festival")
+        @NotBlank String title,
+        @Schema(description = "Event start time in UTC (ISO-8601)", example = "2026-07-15T19:00:00Z")
+        @NotNull Instant startTime,
+        @Schema(description = "Venue name", example = "Madison Square Garden")
+        @NotBlank String venue) {
 }

--- a/backend/src/main/java/com/fairtix/events/dto/EventResponse.java
+++ b/backend/src/main/java/com/fairtix/events/dto/EventResponse.java
@@ -5,33 +5,40 @@ import java.util.UUID;
 
 import com.fairtix.events.domain.Event;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * Response payload for an event
  *
  * Returned by event api endpoints
- * 
+ *
  * @param id        the unique id of the event
  * @param title     the event title
  * @param startTime the event start time in UTC (ISO-8601)
  * @param venue     the name of the venue
  */
+@Schema(description = "Event details")
 public record EventResponse(
-    UUID id,
-    String title,
-    Instant startTime,
-    String venue) {
+        @Schema(description = "Event ID", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+        UUID id,
+        @Schema(description = "Event title", example = "Summer Music Festival")
+        String title,
+        @Schema(description = "Start time in UTC", example = "2026-07-15T19:00:00Z")
+        Instant startTime,
+        @Schema(description = "Venue name", example = "Madison Square Garden")
+        String venue) {
 
-  /**
-   * Maps an {@link Event} object to an API response.
-   *
-   * @param event the event entity
-   * @return the corresponding {@link EventResponse}
-   */
-  public static EventResponse from(Event event) {
-    return new EventResponse(
-        event.getId(),
-        event.getTitle(),
-        event.getStartTime(),
-        event.getVenue());
-  }
+    /**
+     * Maps an {@link Event} object to an API response.
+     *
+     * @param event the event entity
+     * @return the corresponding {@link EventResponse}
+     */
+    public static EventResponse from(Event event) {
+        return new EventResponse(
+                event.getId(),
+                event.getTitle(),
+                event.getStartTime(),
+                event.getVenue());
+    }
 }

--- a/backend/src/main/java/com/fairtix/events/dto/UpdateEventRequest.java
+++ b/backend/src/main/java/com/fairtix/events/dto/UpdateEventRequest.java
@@ -2,11 +2,15 @@ package com.fairtix.events.dto;
 
 import java.time.Instant;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "Payload for updating an event")
 public record UpdateEventRequest(
+        @Schema(description = "Updated event title", example = "Summer Music Festival 2026")
         @NotBlank @Size(max = 500) String title,
+        @Schema(description = "Updated start time in UTC", example = "2026-07-16T20:00:00Z")
         @NotNull Instant startTime) {
 }

--- a/backend/src/main/java/com/fairtix/events/infrastructure/EventRepository.java
+++ b/backend/src/main/java/com/fairtix/events/infrastructure/EventRepository.java
@@ -3,9 +3,17 @@ package com.fairtix.events.infrastructure;
 import com.fairtix.events.domain.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 public interface EventRepository extends JpaRepository<Event, UUID>,
     JpaSpecificationExecutor<Event> {
+
+  long countByStartTimeAfter(Instant now);
+
+  @Query("SELECT e.venue, COUNT(e) FROM Event e GROUP BY e.venue")
+  List<Object[]> countByVenueGrouped();
 }

--- a/backend/src/main/java/com/fairtix/inventory/api/SeatController.java
+++ b/backend/src/main/java/com/fairtix/inventory/api/SeatController.java
@@ -4,6 +4,11 @@ import com.fairtix.inventory.application.SeatService;
 import com.fairtix.inventory.dto.CreateSeatRequest;
 import com.fairtix.inventory.dto.SeatResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.security.PermitAll;
 
 import org.springframework.http.HttpStatus;
@@ -16,58 +21,72 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Manages the seat inventory for events.
+ *
+ * <p>Admins can create seats; anyone can list them.
+ */
+@Tag(name = "Seats", description = "Seat inventory for events")
 @RestController
 @RequestMapping("/api/events/{eventId}/seats")
 public class SeatController {
 
-  private static final Logger log = LoggerFactory.getLogger(SeatController.class);
-  private final SeatService seatService;
+    private static final Logger log = LoggerFactory.getLogger(SeatController.class);
+    private final SeatService seatService;
 
-  public SeatController(SeatService seatService) {
-    this.seatService = seatService;
-  }
+    public SeatController(SeatService seatService) {
+        this.seatService = seatService;
+    }
 
-  /**
-   * Creates a single seat for an event.
-   * Intended for dev/testing — seed seats before placing holds.
-   *
-   * @param eventId the owning event
-   * @param request the seat details
-   * @return the created seat
-   */
-  @PreAuthorize("hasRole('ADMIN')")
-  @PostMapping
-  @ResponseStatus(HttpStatus.CREATED)
-  public SeatResponse createSeat(
-      @PathVariable UUID eventId,
-      @RequestBody CreateSeatRequest request) {
+    /**
+     * Creates a single seat for an event.
+     * Intended for dev/testing — seed seats before placing holds.
+     *
+     * @param eventId the owning event
+     * @param request the seat details
+     * @return the created seat
+     */
+    @Operation(summary = "Create a seat", description = "Admin-only. Adds a seat to an event's inventory.")
+    @ApiResponse(responseCode = "201", description = "Seat created")
+    @ApiResponse(responseCode = "404", description = "Event not found")
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public SeatResponse createSeat(
+            @PathVariable UUID eventId,
+            @RequestBody CreateSeatRequest request) {
 
-    log.info("Request to create seat for event {} section={} row={} seat={}",
-            eventId, request.section(), request.rowLabel(), request.seatNumber());
+        log.info("Request to create seat for event {} section={} row={} seat={}",
+                eventId, request.section(), request.rowLabel(), request.seatNumber());
 
-    return SeatResponse.from(
-        seatService.createSeat(eventId, request.section(), request.rowLabel(), request.seatNumber()));
-  }
+        return SeatResponse.from(
+                seatService.createSeat(eventId, request.section(), request.rowLabel(), request.seatNumber()));
+    }
 
-  /**
-   * Lists seats for an event, optionally filtered to available seats only.
-   *
-   * @param eventId       the event id
-   * @param availableOnly when {@code true} only AVAILABLE seats are returned
-   * @return list of matching seats
-   */
-  @PermitAll
-  @GetMapping
-  public List<SeatResponse> getSeats(
-      @PathVariable UUID eventId,
-      @RequestParam(required = false, defaultValue = "false") boolean availableOnly) {
+    /**
+     * Lists seats for an event, optionally filtered to available seats only.
+     *
+     * @param eventId       the event id
+     * @param availableOnly when {@code true} only AVAILABLE seats are returned
+     * @return list of matching seats
+     */
+    @Operation(summary = "List seats for an event",
+            description = "Public. Returns all seats, optionally filtered to available only.")
+    @ApiResponse(responseCode = "200", description = "List of seats")
+    @SecurityRequirements
+    @PermitAll
+    @GetMapping
+    public List<SeatResponse> getSeats(
+            @PathVariable UUID eventId,
+            @Parameter(description = "Return only AVAILABLE seats")
+            @RequestParam(required = false, defaultValue = "false") boolean availableOnly) {
 
-    log.info("Request to fetch seats for event {} (availableOnly={})",
-            eventId, availableOnly);
+        log.info("Request to fetch seats for event {} (availableOnly={})",
+                eventId, availableOnly);
 
-    var seats = availableOnly
-        ? seatService.getAvailableSeatsForEvent(eventId)
-        : seatService.getSeatsForEvent(eventId);
-    return seats.stream().map(SeatResponse::from).toList();
-  }
+        var seats = availableOnly
+                ? seatService.getAvailableSeatsForEvent(eventId)
+                : seatService.getSeatsForEvent(eventId);
+        return seats.stream().map(SeatResponse::from).toList();
+    }
 }

--- a/backend/src/main/java/com/fairtix/inventory/api/SeatHoldController.java
+++ b/backend/src/main/java/com/fairtix/inventory/api/SeatHoldController.java
@@ -5,6 +5,10 @@ import com.fairtix.inventory.domain.HoldStatus;
 import com.fairtix.inventory.dto.CreateHoldRequest;
 import com.fairtix.inventory.dto.SeatHoldResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.security.PermitAll;
 import jakarta.validation.Valid;
 
@@ -15,97 +19,136 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * Manages temporary seat holds and their lifecycle (create → confirm / release).
+ *
+ * <p>Holds expire automatically after a configurable duration. Confirm and release
+ * operations are idempotent — safe to retry without side effects.
+ */
+@Tag(name = "Holds", description = "Seat hold lifecycle")
 @RestController
 public class SeatHoldController {
 
-  private final SeatHoldService seatHoldService;
+    private final SeatHoldService seatHoldService;
 
-  public SeatHoldController(SeatHoldService seatHoldService) {
-    this.seatHoldService = seatHoldService;
-  }
+    public SeatHoldController(SeatHoldService seatHoldService) {
+        this.seatHoldService = seatHoldService;
+    }
 
-  /**
-   * Places a hold on one or more seats for an event.
-   *
-   * POST /api/events/{eventId}/holds
-   * Body: { "seatIds": ["..."], "holderId": "...", "durationMinutes": 10 }
-   *
-   * @return 201 Created with the list of created holds
-   */
-  @PreAuthorize("isAuthenticated()")
-  @PostMapping("/api/events/{eventId}/holds")
-  @ResponseStatus(HttpStatus.CREATED)
-  public List<SeatHoldResponse> createHold(
-      @PathVariable UUID eventId,
-      @Valid @RequestBody CreateHoldRequest request) {
-    return seatHoldService
-        .createHold(eventId, request.seatIds(), request.holderId(), request.durationMinutes())
-        .stream()
-        .map(SeatHoldResponse::from)
-        .toList();
-  }
+    /**
+     * Places a hold on one or more seats for an event.
+     *
+     * POST /api/events/{eventId}/holds
+     * Body: { "seatIds": ["..."], "holderId": "...", "durationMinutes": 10 }
+     *
+     * @param eventId the event whose seats to hold
+     * @param request seat IDs, holder identifier, and optional duration
+     * @return 201 Created with the list of created holds
+     */
+    @Operation(summary = "Create a seat hold",
+            description = "Authenticated. Temporarily reserves 1–10 seats for the holder.")
+    @ApiResponse(responseCode = "201", description = "Holds created")
+    @ApiResponse(responseCode = "400", description = "Validation error")
+    @ApiResponse(responseCode = "409", description = "One or more seats not available")
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/api/events/{eventId}/holds")
+    @ResponseStatus(HttpStatus.CREATED)
+    public List<SeatHoldResponse> createHold(
+            @PathVariable UUID eventId,
+            @Valid @RequestBody CreateHoldRequest request) {
+        return seatHoldService
+                .createHold(eventId, request.seatIds(), request.holderId(), request.durationMinutes())
+                .stream()
+                .map(SeatHoldResponse::from)
+                .toList();
+    }
 
-  /**
-   * Lists holds for a given holder, optionally filtered by status.
-   *
-   * GET /api/holds?holderId=...&status=ACTIVE
-   *
-   * @return 200 OK with the matching holds (empty list if none)
-   */
-  @GetMapping("/api/holds")
-  public List<SeatHoldResponse> listHolds(
-      @RequestParam String holderId,
-      @RequestParam(defaultValue = "ACTIVE") HoldStatus status) {
-    return seatHoldService.listHolds(holderId, status)
-        .stream()
-        .map(SeatHoldResponse::from)
-        .toList();
-  }
+    /**
+     * Lists holds for a given holder, optionally filtered by status.
+     *
+     * GET /api/holds?holderId=...&amp;status=ACTIVE
+     *
+     * @param holderId the holder's identifier
+     * @param status   hold status filter (defaults to ACTIVE)
+     * @return 200 OK with the matching holds (empty list if none)
+     */
+    @Operation(summary = "List holds for a holder",
+            description = "Returns holds matching the given holder and status.")
+    @ApiResponse(responseCode = "200", description = "List of holds")
+    @GetMapping("/api/holds")
+    public List<SeatHoldResponse> listHolds(
+            @Parameter(description = "Holder identifier") @RequestParam String holderId,
+            @Parameter(description = "Filter by status") @RequestParam(defaultValue = "ACTIVE") HoldStatus status) {
+        return seatHoldService.listHolds(holderId, status)
+                .stream()
+                .map(SeatHoldResponse::from)
+                .toList();
+    }
 
-  /**
-   * Returns hold details visible only to the original holder.
-   *
-   * GET /api/holds/{holdId}?holderId=...
-   *
-   * @return 200 OK with the hold, or 404 if not found for this holder
-   */
-  @PermitAll
-  @GetMapping("/api/holds/{holdId}")
-  public SeatHoldResponse getHold(
-      @PathVariable UUID holdId,
-      @RequestParam String holderId) {
-    return SeatHoldResponse.from(seatHoldService.getHold(holdId, holderId));
-  }
+    /**
+     * Returns hold details visible only to the original holder.
+     *
+     * GET /api/holds/{holdId}?holderId=...
+     *
+     * @param holdId   the hold's unique ID
+     * @param holderId the holder's identifier (ownership check)
+     * @return 200 OK with the hold, or 404 if not found for this holder
+     */
+    @Operation(summary = "Get a hold by ID",
+            description = "Returns a single hold, scoped to the given holder.")
+    @ApiResponse(responseCode = "200", description = "Hold found")
+    @ApiResponse(responseCode = "404", description = "Hold not found for this holder")
+    @PermitAll
+    @GetMapping("/api/holds/{holdId}")
+    public SeatHoldResponse getHold(
+            @PathVariable UUID holdId,
+            @Parameter(description = "Holder identifier") @RequestParam String holderId) {
+        return SeatHoldResponse.from(seatHoldService.getHold(holdId, holderId));
+    }
 
-  /**
-   * Releases an active hold, freeing the seat for others.
-   * Idempotent: calling release on an already-RELEASED hold returns 200.
-   *
-   * POST /api/holds/{holdId}/release?holderId=...
-   *
-   * @return 200 OK with the updated hold
-   */
-  @PreAuthorize("isAuthenticated()")
-  @PostMapping("/api/holds/{holdId}/release")
-  public SeatHoldResponse releaseHold(
-      @PathVariable UUID holdId,
-      @RequestParam String holderId) {
-    return SeatHoldResponse.from(seatHoldService.releaseHold(holdId, holderId));
-  }
+    /**
+     * Releases an active hold, freeing the seat for others.
+     * Idempotent: calling release on an already-RELEASED hold returns 200.
+     *
+     * POST /api/holds/{holdId}/release?holderId=...
+     *
+     * @param holdId   the hold to release
+     * @param holderId the holder's identifier (ownership check)
+     * @return 200 OK with the updated hold
+     */
+    @Operation(summary = "Release a hold",
+            description = "Authenticated. Idempotent — frees the seat back to AVAILABLE.")
+    @ApiResponse(responseCode = "200", description = "Hold released")
+    @ApiResponse(responseCode = "404", description = "Hold not found")
+    @ApiResponse(responseCode = "409", description = "Hold already confirmed")
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/api/holds/{holdId}/release")
+    public SeatHoldResponse releaseHold(
+            @PathVariable UUID holdId,
+            @Parameter(description = "Holder identifier") @RequestParam String holderId) {
+        return SeatHoldResponse.from(seatHoldService.releaseHold(holdId, holderId));
+    }
 
-  /**
-   * Confirms an active hold, transitioning the seat to BOOKED.
-   * Idempotent: calling confirm on an already-CONFIRMED hold returns 200.
-   *
-   * POST /api/holds/{holdId}/confirm?holderId=...
-   *
-   * @return 200 OK with the updated hold
-   */
-  @PreAuthorize("isAuthenticated()")
-  @PostMapping("/api/holds/{holdId}/confirm")
-  public SeatHoldResponse confirmHold(
-      @PathVariable UUID holdId,
-      @RequestParam String holderId) {
-    return SeatHoldResponse.from(seatHoldService.confirmHold(holdId, holderId));
-  }
+    /**
+     * Confirms an active hold, transitioning the seat to BOOKED.
+     * Idempotent: calling confirm on an already-CONFIRMED hold returns 200.
+     *
+     * POST /api/holds/{holdId}/confirm?holderId=...
+     *
+     * @param holdId   the hold to confirm
+     * @param holderId the holder's identifier (ownership check)
+     * @return 200 OK with the updated hold
+     */
+    @Operation(summary = "Confirm a hold",
+            description = "Authenticated. Idempotent — transitions the seat to BOOKED.")
+    @ApiResponse(responseCode = "200", description = "Hold confirmed")
+    @ApiResponse(responseCode = "404", description = "Hold not found")
+    @ApiResponse(responseCode = "409", description = "Hold expired or already released")
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/api/holds/{holdId}/confirm")
+    public SeatHoldResponse confirmHold(
+            @PathVariable UUID holdId,
+            @Parameter(description = "Holder identifier") @RequestParam String holderId) {
+        return SeatHoldResponse.from(seatHoldService.confirmHold(holdId, holderId));
+    }
 }

--- a/backend/src/main/java/com/fairtix/inventory/dto/CreateHoldRequest.java
+++ b/backend/src/main/java/com/fairtix/inventory/dto/CreateHoldRequest.java
@@ -1,5 +1,6 @@
 package com.fairtix.inventory.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -15,19 +16,26 @@ import java.util.UUID;
  * The service also enforces {@code holds.max-seats-per-hold} and
  * {@code holds.max-duration-minutes} so the limits hold even for direct calls.
  *
- * @param seatIds         the seats to hold (1–10 items)
+ * @param seatIds         the seats to hold (1-10 items)
  * @param holderId        opaque identifier for the holder (session/user id)
  * @param durationMinutes how long the hold lasts; server default when null
  */
+@Schema(description = "Payload for creating a temporary seat hold")
 public record CreateHoldRequest(
 
-    @NotEmpty(message = "At least one seat is required")
-    @Size(max = 10, message = "Cannot request more than 10 seats per hold")
-    List<UUID> seatIds,
+        @Schema(description = "Seat IDs to hold (1-10)",
+                example = "[\"a1b2c3d4-e5f6-7890-abcd-ef1234567890\"]")
+        @NotEmpty(message = "At least one seat is required")
+        @Size(max = 10, message = "Cannot request more than 10 seats per hold")
+        List<UUID> seatIds,
 
-    @NotBlank(message = "holderId must not be blank")
-    String holderId,
+        @Schema(description = "Opaque holder identifier (session or user ID)",
+                example = "user-session-abc123")
+        @NotBlank(message = "holderId must not be blank")
+        String holderId,
 
-    @Min(value = 1, message = "durationMinutes must be at least 1")
-    Integer durationMinutes) {
+        @Schema(description = "Hold duration in minutes (server default if omitted, max 60)",
+                example = "10")
+        @Min(value = 1, message = "durationMinutes must be at least 1")
+        Integer durationMinutes) {
 }

--- a/backend/src/main/java/com/fairtix/inventory/dto/CreateSeatRequest.java
+++ b/backend/src/main/java/com/fairtix/inventory/dto/CreateSeatRequest.java
@@ -1,5 +1,7 @@
 package com.fairtix.inventory.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * Request payload for creating a seat.
  *
@@ -7,8 +9,12 @@ package com.fairtix.inventory.dto;
  * @param rowLabel   the row within the section (e.g. "A", "B")
  * @param seatNumber the seat identifier within the row (e.g. "101")
  */
+@Schema(description = "Payload for creating a seat in an event's inventory")
 public record CreateSeatRequest(
-    String section,
-    String rowLabel,
-    String seatNumber) {
+        @Schema(description = "Seating section label", example = "Floor")
+        String section,
+        @Schema(description = "Row within the section", example = "A")
+        String rowLabel,
+        @Schema(description = "Seat identifier within the row", example = "101")
+        String seatNumber) {
 }

--- a/backend/src/main/java/com/fairtix/inventory/dto/SeatHoldResponse.java
+++ b/backend/src/main/java/com/fairtix/inventory/dto/SeatHoldResponse.java
@@ -3,6 +3,8 @@ package com.fairtix.inventory.dto;
 import com.fairtix.inventory.domain.HoldStatus;
 import com.fairtix.inventory.domain.SeatHold;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.Instant;
 import java.util.UUID;
 
@@ -17,29 +19,37 @@ import java.util.UUID;
  * @param createdAt when the hold was created (UTC)
  * @param status    the current hold status
  */
+@Schema(description = "Seat hold details")
 public record SeatHoldResponse(
-    UUID id,
-    UUID seatId,
-    UUID eventId,
-    String holderId,
-    Instant expiresAt,
-    Instant createdAt,
-    HoldStatus status) {
+        @Schema(description = "Hold ID", example = "c3d4e5f6-a7b8-9012-cdef-123456789012")
+        UUID id,
+        @Schema(description = "Held seat ID", example = "b2c3d4e5-f6a7-8901-bcde-f12345678901")
+        UUID seatId,
+        @Schema(description = "Event ID", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+        UUID eventId,
+        @Schema(description = "Holder identifier", example = "user-session-abc123")
+        String holderId,
+        @Schema(description = "Hold expiry time in UTC", example = "2026-07-15T19:10:00Z")
+        Instant expiresAt,
+        @Schema(description = "Hold creation time in UTC", example = "2026-07-15T19:00:00Z")
+        Instant createdAt,
+        @Schema(description = "Hold status", example = "ACTIVE")
+        HoldStatus status) {
 
-  /**
-   * Maps a {@link SeatHold} entity to a {@link SeatHoldResponse}.
-   *
-   * @param hold the hold entity
-   * @return the corresponding response
-   */
-  public static SeatHoldResponse from(SeatHold hold) {
-    return new SeatHoldResponse(
-        hold.getId(),
-        hold.getSeat().getId(),
-        hold.getSeat().getEvent().getId(),
-        hold.getHolderId(),
-        hold.getExpiresAt(),
-        hold.getCreatedAt(),
-        hold.getStatus());
-  }
+    /**
+     * Maps a {@link SeatHold} entity to a {@link SeatHoldResponse}.
+     *
+     * @param hold the hold entity
+     * @return the corresponding response
+     */
+    public static SeatHoldResponse from(SeatHold hold) {
+        return new SeatHoldResponse(
+                hold.getId(),
+                hold.getSeat().getId(),
+                hold.getSeat().getEvent().getId(),
+                hold.getHolderId(),
+                hold.getExpiresAt(),
+                hold.getCreatedAt(),
+                hold.getStatus());
+    }
 }

--- a/backend/src/main/java/com/fairtix/inventory/dto/SeatResponse.java
+++ b/backend/src/main/java/com/fairtix/inventory/dto/SeatResponse.java
@@ -3,6 +3,8 @@ package com.fairtix.inventory.dto;
 import com.fairtix.inventory.domain.Seat;
 import com.fairtix.inventory.domain.SeatStatus;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.UUID;
 
 /**
@@ -15,27 +17,34 @@ import java.util.UUID;
  * @param seatNumber the individual seat number
  * @param status     the current availability status
  */
+@Schema(description = "Seat details")
 public record SeatResponse(
-    UUID id,
-    UUID eventId,
-    String section,
-    String rowLabel,
-    String seatNumber,
-    SeatStatus status) {
+        @Schema(description = "Seat ID", example = "b2c3d4e5-f6a7-8901-bcde-f12345678901")
+        UUID id,
+        @Schema(description = "Event ID", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+        UUID eventId,
+        @Schema(description = "Seating section", example = "Floor")
+        String section,
+        @Schema(description = "Row label", example = "A")
+        String rowLabel,
+        @Schema(description = "Seat number", example = "101")
+        String seatNumber,
+        @Schema(description = "Availability status", example = "AVAILABLE")
+        SeatStatus status) {
 
-  /**
-   * Maps a {@link Seat} entity to a {@link SeatResponse}.
-   *
-   * @param seat the seat entity
-   * @return the corresponding response
-   */
-  public static SeatResponse from(Seat seat) {
-    return new SeatResponse(
-        seat.getId(),
-        seat.getEvent().getId(),
-        seat.getSection(),
-        seat.getRowLabel(),
-        seat.getSeatNumber(),
-        seat.getStatus());
-  }
+    /**
+     * Maps a {@link Seat} entity to a {@link SeatResponse}.
+     *
+     * @param seat the seat entity
+     * @return the corresponding response
+     */
+    public static SeatResponse from(Seat seat) {
+        return new SeatResponse(
+                seat.getId(),
+                seat.getEvent().getId(),
+                seat.getSection(),
+                seat.getRowLabel(),
+                seat.getSeatNumber(),
+                seat.getStatus());
+    }
 }

--- a/backend/src/main/java/com/fairtix/inventory/infrastructure/SeatHoldRepository.java
+++ b/backend/src/main/java/com/fairtix/inventory/infrastructure/SeatHoldRepository.java
@@ -5,6 +5,8 @@ import com.fairtix.inventory.domain.SeatHold;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.Instant;
 import java.util.List;
@@ -12,6 +14,12 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface SeatHoldRepository extends JpaRepository<SeatHold, UUID> {
+
+  @Query("SELECT sh.status, COUNT(sh) FROM SeatHold sh GROUP BY sh.status")
+  List<Object[]> countByStatusGrouped();
+
+  @Query(value = "SELECT DATE(sh.created_at) AS day, COUNT(*) FROM seat_holds sh WHERE sh.created_at >= :since GROUP BY DATE(sh.created_at) ORDER BY day", nativeQuery = true)
+  List<Object[]> countHoldsPerDay(@Param("since") Instant since);
 
   Optional<SeatHold> findByIdAndHolderId(UUID id, String holderId);
 

--- a/backend/src/main/java/com/fairtix/inventory/infrastructure/SeatHoldRepository.java
+++ b/backend/src/main/java/com/fairtix/inventory/infrastructure/SeatHoldRepository.java
@@ -18,7 +18,7 @@ public interface SeatHoldRepository extends JpaRepository<SeatHold, UUID> {
   @Query("SELECT sh.status, COUNT(sh) FROM SeatHold sh GROUP BY sh.status")
   List<Object[]> countByStatusGrouped();
 
-  @Query(value = "SELECT DATE(sh.created_at) AS day, COUNT(*) FROM seat_holds sh WHERE sh.created_at >= :since GROUP BY DATE(sh.created_at) ORDER BY day", nativeQuery = true)
+  @Query(value = "SELECT CAST(sh.created_at AS DATE) AS hold_date, COUNT(*) FROM seat_holds sh WHERE sh.created_at >= :since GROUP BY CAST(sh.created_at AS DATE) ORDER BY hold_date", nativeQuery = true)
   List<Object[]> countHoldsPerDay(@Param("since") Instant since);
 
   Optional<SeatHold> findByIdAndHolderId(UUID id, String holderId);

--- a/backend/src/main/java/com/fairtix/inventory/infrastructure/SeatRepository.java
+++ b/backend/src/main/java/com/fairtix/inventory/infrastructure/SeatRepository.java
@@ -14,6 +14,12 @@ import java.util.UUID;
 
 public interface SeatRepository extends JpaRepository<Seat, UUID> {
 
+  @Query("SELECT s.status, COUNT(s) FROM Seat s GROUP BY s.status")
+  List<Object[]> countByStatusGrouped();
+
+  @Query("SELECT s.event.id, s.event.title, s.status, COUNT(s) FROM Seat s GROUP BY s.event.id, s.event.title, s.status")
+  List<Object[]> countByEventAndStatus();
+
   List<Seat> findByEvent_Id(UUID eventId);
 
   List<Seat> findByEvent_IdAndStatus(UUID eventId, SeatStatus status);

--- a/backend/src/main/java/com/fairtix/users/api/AdminController.java
+++ b/backend/src/main/java/com/fairtix/users/api/AdminController.java
@@ -15,33 +15,61 @@ import com.fairtix.users.domain.User;
 import com.fairtix.users.domain.Role;
 import com.fairtix.users.dto.UserResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 import java.util.UUID;
 
+/**
+ * Admin-only user management endpoints.
+ *
+ * <p>Provides a paginated user list and the ability to promote users to admin.
+ */
+@Tag(name = "Admin", description = "User administration")
 @RestController
 @RequestMapping("/api/admin")
 @RequiredArgsConstructor
 public class AdminController {
 
-  private final UserRepository userRepository;
+    private final UserRepository userRepository;
 
-  @GetMapping("/users")
-  @PreAuthorize("hasRole('ADMIN')")
-  public Page<UserResponse> listUsers(
-      @RequestParam(defaultValue = "0") int page,
-      @RequestParam(defaultValue = "20") int size) {
-    return userRepository.findAll(PageRequest.of(page, Math.min(size, 100)))
-        .map(UserResponse::from);
-  }
+    /**
+     * Returns a paginated list of all users.
+     *
+     * @param page zero-based page index
+     * @param size number of users per page (max 100)
+     * @return a page of user records
+     */
+    @Operation(summary = "List all users", description = "Admin-only. Returns a paginated list of users.")
+    @ApiResponse(responseCode = "200", description = "Page of users")
+    @ApiResponse(responseCode = "403", description = "Not an admin")
+    @GetMapping("/users")
+    @PreAuthorize("hasRole('ADMIN')")
+    public Page<UserResponse> listUsers(
+            @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size (max 100)") @RequestParam(defaultValue = "20") int size) {
+        return userRepository.findAll(PageRequest.of(page, Math.min(size, 100)))
+                .map(UserResponse::from);
+    }
 
-  @PatchMapping("/users/{id}/promote")
-  @PreAuthorize("hasRole('ADMIN')")
-  public void promoteUser(@PathVariable UUID id) {
-    User user = userRepository.findById(id)
-        .orElseThrow(() -> new IllegalArgumentException("User not found: " + id));
+    /**
+     * Promotes a user to the ADMIN role.
+     *
+     * @param id the UUID of the user to promote
+     */
+    @Operation(summary = "Promote user to admin", description = "Admin-only. Sets the user's role to ADMIN.")
+    @ApiResponse(responseCode = "200", description = "User promoted")
+    @ApiResponse(responseCode = "400", description = "User not found")
+    @PatchMapping("/users/{id}/promote")
+    @PreAuthorize("hasRole('ADMIN')")
+    public void promoteUser(@PathVariable UUID id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + id));
 
-    user.setRole(Role.ADMIN);
-    userRepository.save(user);
-  }
+        user.setRole(Role.ADMIN);
+        userRepository.save(user);
+    }
 }

--- a/backend/src/main/java/com/fairtix/users/dto/AuthResponse.java
+++ b/backend/src/main/java/com/fairtix/users/dto/AuthResponse.java
@@ -1,0 +1,9 @@
+package com.fairtix.users.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Authentication response containing a JWT token")
+public record AuthResponse(
+        @Schema(description = "JWT bearer token", example = "eyJhbGciOiJIUzI1NiJ9...")
+        String token) {
+}

--- a/backend/src/main/java/com/fairtix/users/dto/LoginRequest.java
+++ b/backend/src/main/java/com/fairtix/users/dto/LoginRequest.java
@@ -1,6 +1,11 @@
 package com.fairtix.users.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Login credentials")
 public record LoginRequest(
-    String email,
-    String password) {
+        @Schema(description = "User email address", example = "user@example.com")
+        String email,
+        @Schema(description = "User password", example = "password123")
+        String password) {
 }

--- a/backend/src/main/java/com/fairtix/users/dto/RegisterRequest.java
+++ b/backend/src/main/java/com/fairtix/users/dto/RegisterRequest.java
@@ -1,6 +1,11 @@
 package com.fairtix.users.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "New user registration payload")
 public record RegisterRequest(
-    String email,
-    String password) {
+        @Schema(description = "Email address for the new account", example = "newuser@example.com")
+        String email,
+        @Schema(description = "Password (plaintext, will be hashed)", example = "password123")
+        String password) {
 }

--- a/backend/src/main/java/com/fairtix/users/dto/UserResponse.java
+++ b/backend/src/main/java/com/fairtix/users/dto/UserResponse.java
@@ -3,9 +3,18 @@ package com.fairtix.users.dto;
 import com.fairtix.users.domain.Role;
 import com.fairtix.users.domain.User;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.UUID;
 
-public record UserResponse(UUID id, String email, Role role) {
+@Schema(description = "User details")
+public record UserResponse(
+        @Schema(description = "User ID", example = "d290f1ee-6c54-4b01-90e6-d701748f0851")
+        UUID id,
+        @Schema(description = "Email address", example = "user@example.com")
+        String email,
+        @Schema(description = "User role", example = "USER")
+        Role role) {
 
     public static UserResponse from(User user) {
         return new UserResponse(user.getId(), user.getEmail(), user.getRole());

--- a/backend/src/main/java/com/fairtix/users/infrastructure/UserRepository.java
+++ b/backend/src/main/java/com/fairtix/users/infrastructure/UserRepository.java
@@ -1,9 +1,11 @@
 package com.fairtix.users.infrastructure;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.fairtix.users.domain.User;
@@ -11,4 +13,7 @@ import com.fairtix.users.domain.User;
 @Repository
 public interface UserRepository extends JpaRepository<User, UUID> {
   Optional<User> findByEmail(String email);
+
+  @Query("SELECT u.role, COUNT(u) FROM User u GROUP BY u.role")
+  List<Object[]> countByRoleGrouped();
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -26,3 +26,9 @@ holds.max-active-per-holder=5
 
 # Logging
 logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} [%X{requestId}] %-5level %logger - %msg%n
+
+# OpenAPI / Swagger
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.operations-sorter=method
+springdoc.swagger-ui.tags-sorter=alpha

--- a/backend/src/test/java/com/fairtix/analytics/api/AnalyticsControllerTest.java
+++ b/backend/src/test/java/com/fairtix/analytics/api/AnalyticsControllerTest.java
@@ -1,0 +1,97 @@
+package com.fairtix.analytics.api;
+
+import com.fairtix.events.application.EventService;
+import com.fairtix.inventory.application.SeatService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.Instant;
+
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Transactional
+class AnalyticsControllerTest {
+
+  @Autowired
+  private WebApplicationContext context;
+
+  @Autowired
+  private EventService eventService;
+
+  @Autowired
+  private SeatService seatService;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context)
+        .apply(springSecurity())
+        .build();
+  }
+
+  @Test
+  void getDashboard_asAdmin_returns200WithExpectedShape() throws Exception {
+    // Seed some data so the response has non-empty fields
+    var event = eventService.createEvent("Test Show", Instant.parse("2026-08-01T20:00:00Z"), "Arena A");
+    seatService.createSeat(event.getId(), "VIP", "A", "1");
+    seatService.createSeat(event.getId(), "VIP", "A", "2");
+
+    mockMvc.perform(get("/api/analytics/dashboard")
+            .with(user("admin@test.com").roles("ADMIN"))
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.overview").value(notNullValue()))
+        .andExpect(jsonPath("$.overview.totalEvents").value(1))
+        .andExpect(jsonPath("$.overview.totalSeats").value(2))
+        .andExpect(jsonPath("$.overview.totalUsers").value(0))
+        .andExpect(jsonPath("$.seatsByStatus").value(hasKey("AVAILABLE")))
+        .andExpect(jsonPath("$.seatsByStatus").value(hasKey("HELD")))
+        .andExpect(jsonPath("$.seatsByStatus").value(hasKey("BOOKED")))
+        .andExpect(jsonPath("$.holdsByStatus").value(hasKey("ACTIVE")))
+        .andExpect(jsonPath("$.holdConfirmationRate").value(0.0))
+        .andExpect(jsonPath("$.holdsPerDay").isArray())
+        .andExpect(jsonPath("$.eventsByVenue").isArray())
+        .andExpect(jsonPath("$.topEventsByBookings").isArray())
+        .andExpect(jsonPath("$.usersByRole").exists());
+  }
+
+  @Test
+  void getDashboard_asUser_returns403() throws Exception {
+    mockMvc.perform(get("/api/analytics/dashboard")
+            .with(user("user@test.com").roles("USER")))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void getDashboard_unauthenticated_returns403() throws Exception {
+    mockMvc.perform(get("/api/analytics/dashboard"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void getDashboard_emptyDatabase_returns200WithZeros() throws Exception {
+    mockMvc.perform(get("/api/analytics/dashboard")
+            .with(user("admin@test.com").roles("ADMIN"))
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.overview.totalEvents").value(0))
+        .andExpect(jsonPath("$.overview.totalSeats").value(0))
+        .andExpect(jsonPath("$.overview.bookedSeats").value(0))
+        .andExpect(jsonPath("$.overview.activeHolds").value(0))
+        .andExpect(jsonPath("$.holdConfirmationRate").value(0.0));
+  }
+}

--- a/backend/src/test/java/com/fairtix/config/TestRedisConfig.java
+++ b/backend/src/test/java/com/fairtix/config/TestRedisConfig.java
@@ -1,0 +1,31 @@
+package com.fairtix.config;
+
+import org.mockito.Mockito;
+import org.redisson.api.RRateLimiter;
+import org.redisson.api.RedissonClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Replaces the real RedissonClient with a mock for tests,
+ * so tests don't need a running Redis instance.
+ */
+@Configuration
+public class TestRedisConfig {
+
+  @Bean
+  @Primary
+  public RedissonClient redissonClient() {
+    RedissonClient mock = Mockito.mock(RedissonClient.class);
+    RRateLimiter limiter = Mockito.mock(RRateLimiter.class);
+    when(mock.getRateLimiter(anyString())).thenReturn(limiter);
+    when(limiter.tryAcquire(1)).thenReturn(true);
+    when(limiter.isExists()).thenReturn(false);
+    when(limiter.trySetRate(Mockito.any(), Mockito.anyLong(), Mockito.anyLong(), Mockito.any())).thenReturn(true);
+    return mock;
+  }
+}

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -1,0 +1,254 @@
+# FairTix API Contract
+
+> **Version:** 1.0.0
+> **Base URL:** `http://localhost:8080`
+> **Interactive docs:** `http://localhost:8080/swagger-ui.html`
+> **OpenAPI spec:** `http://localhost:8080/v3/api-docs`
+
+## Authentication
+
+All protected endpoints require a JWT bearer token in the `Authorization` header:
+
+```
+Authorization: Bearer <token>
+```
+
+Tokens are obtained from the Auth endpoints and expire after 15 minutes.
+
+---
+
+## Implemented Endpoints
+
+### Auth
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/auth/register` | Public | Register a new user |
+| POST | `/auth/login` | Public | Log in and receive a JWT |
+
+**Request body (both):**
+```json
+{
+  "email": "user@example.com",
+  "password": "password123"
+}
+```
+
+**Response:**
+```json
+{
+  "token": "eyJhbGciOiJIUzI1NiJ9..."
+}
+```
+
+### Events
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/api/events` | ADMIN | Create an event |
+| GET | `/api/events` | Public | Search/list events (paginated) |
+| GET | `/api/events/{id}` | Public | Get a single event |
+| PUT | `/api/events/{id}` | ADMIN | Update an event |
+| DELETE | `/api/events/{id}` | ADMIN | Delete an event |
+
+**Create/Update request:**
+```json
+{
+  "title": "Summer Music Festival",
+  "startTime": "2026-07-15T19:00:00Z",
+  "venue": "Madison Square Garden"
+}
+```
+
+**Event response:**
+```json
+{
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "title": "Summer Music Festival",
+  "startTime": "2026-07-15T19:00:00Z",
+  "venue": "Madison Square Garden"
+}
+```
+
+**Search query parameters:** `venueName`, `title`, `upcoming` (boolean), `page` (default 0), `size` (default 20, max 100)
+
+### Seats
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/api/events/{eventId}/seats` | ADMIN | Create a seat |
+| GET | `/api/events/{eventId}/seats` | Public | List seats for an event |
+
+**Create request:**
+```json
+{
+  "section": "Floor",
+  "rowLabel": "A",
+  "seatNumber": "101"
+}
+```
+
+**Seat response:**
+```json
+{
+  "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  "eventId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "section": "Floor",
+  "rowLabel": "A",
+  "seatNumber": "101",
+  "status": "AVAILABLE"
+}
+```
+
+**List query parameters:** `availableOnly` (boolean, default false)
+
+### Holds
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/api/events/{eventId}/holds` | Authenticated | Create a hold on 1-10 seats |
+| GET | `/api/holds` | Authenticated | List holds for a holder |
+| GET | `/api/holds/{holdId}` | Public | Get a single hold |
+| POST | `/api/holds/{holdId}/release` | Authenticated | Release a hold (idempotent) |
+| POST | `/api/holds/{holdId}/confirm` | Authenticated | Confirm a hold (idempotent) |
+
+**Create hold request:**
+```json
+{
+  "seatIds": ["b2c3d4e5-f6a7-8901-bcde-f12345678901"],
+  "holderId": "user-session-abc123",
+  "durationMinutes": 10
+}
+```
+
+**Hold response:**
+```json
+{
+  "id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+  "seatId": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  "eventId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "holderId": "user-session-abc123",
+  "expiresAt": "2026-07-15T19:10:00Z",
+  "createdAt": "2026-07-15T19:00:00Z",
+  "status": "ACTIVE"
+}
+```
+
+**Hold statuses:** `ACTIVE`, `CONFIRMED`, `EXPIRED`, `RELEASED`
+
+**Constraints:**
+- Max 10 seats per hold request
+- Max 5 active holds per holder
+- Duration: 1-60 minutes (default 10)
+- Holds expire automatically after the specified duration
+
+### Analytics
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/api/analytics/dashboard` | ADMIN | Aggregate dashboard stats |
+
+**Response:** see Swagger UI for the full `AnalyticsResponse` schema.
+
+### Admin
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/api/admin/users` | ADMIN | List all users (paginated) |
+| PATCH | `/api/admin/users/{id}/promote` | ADMIN | Promote a user to admin |
+
+---
+
+## Error Response Format
+
+All errors follow a consistent shape:
+
+```json
+{
+  "status": 409,
+  "code": "HOLD_CONFLICT",
+  "message": "Seat b2c3d4e5-... is not available",
+  "path": "/api/holds/abc/confirm",
+  "timestamp": "2026-07-15T19:00:00Z"
+}
+```
+
+**Error codes:** `HOLD_NOT_FOUND`, `HOLD_CONFLICT`, `BAD_REQUEST`, `VALIDATION_ERROR`, `UNAUTHORIZED`, `FORBIDDEN`, `RESOURCE_NOT_FOUND`
+
+---
+
+## Planned Endpoints (Not Yet Implemented)
+
+### Orders
+
+Future endpoints for completing a purchase after confirming a hold.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/api/orders` | Authenticated | Create an order from confirmed holds |
+| GET | `/api/orders` | Authenticated | List the current user's orders |
+| GET | `/api/orders/{orderId}` | Authenticated | Get order details |
+| POST | `/api/orders/{orderId}/cancel` | Authenticated | Cancel an order (if refundable) |
+| GET | `/api/admin/orders` | ADMIN | List all orders (admin) |
+
+**Planned create order request:**
+```json
+{
+  "holdIds": ["c3d4e5f6-a7b8-9012-cdef-123456789012"],
+  "paymentMethod": "CARD"
+}
+```
+
+**Planned order response:**
+```json
+{
+  "id": "d4e5f6a7-b8c9-0123-defa-234567890123",
+  "userId": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+  "holdIds": ["c3d4e5f6-a7b8-9012-cdef-123456789012"],
+  "status": "COMPLETED",
+  "totalAmount": 75.00,
+  "currency": "USD",
+  "createdAt": "2026-07-15T19:05:00Z"
+}
+```
+
+**Planned order statuses:** `PENDING`, `COMPLETED`, `CANCELLED`, `REFUNDED`
+
+### Tickets
+
+Future endpoints for accessing purchased tickets.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/api/tickets` | Authenticated | List the current user's tickets |
+| GET | `/api/tickets/{ticketId}` | Authenticated | Get ticket details / QR data |
+| POST | `/api/tickets/{ticketId}/transfer` | Authenticated | Transfer a ticket to another user |
+| POST | `/api/admin/tickets/{ticketId}/validate` | ADMIN | Validate a ticket at the door |
+
+**Planned ticket response:**
+```json
+{
+  "id": "e5f6a7b8-c9d0-1234-efab-345678901234",
+  "orderId": "d4e5f6a7-b8c9-0123-defa-234567890123",
+  "eventId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "seatId": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  "holderEmail": "user@example.com",
+  "status": "VALID",
+  "qrCode": "base64-encoded-qr-data",
+  "issuedAt": "2026-07-15T19:05:00Z"
+}
+```
+
+**Planned ticket statuses:** `VALID`, `USED`, `TRANSFERRED`, `CANCELLED`
+
+---
+
+## Frontend Alignment Notes
+
+The frontend currently integrates with:
+- Auth endpoints (login/register)
+- Events listing (`GET /api/events`)
+- Analytics dashboard (`GET /api/analytics/dashboard`)
+- Admin user management (`GET /api/admin/users`, `PATCH .../promote`)
+
+**Not yet wired in the frontend:** Seats, holds, release, confirm. These are backend-ready and awaiting the seat selection / checkout UI.

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -108,7 +108,7 @@ Tokens are obtained from the Auth endpoints and expire after 15 minutes.
 |--------|------|------|-------------|
 | POST | `/api/events/{eventId}/holds` | Authenticated | Create a hold on 1-10 seats |
 | GET | `/api/holds` | Authenticated | List holds for a holder |
-| GET | `/api/holds/{holdId}` | Public | Get a single hold |
+| GET | `/api/holds/{holdId}` | Authenticated | Get a single hold |
 | POST | `/api/holds/{holdId}/release` | Authenticated | Release a hold (idempotent) |
 | POST | `/api/holds/{holdId}/confirm` | Authenticated | Confirm a hold (idempotent) |
 
@@ -121,17 +121,19 @@ Tokens are obtained from the Auth endpoints and expire after 15 minutes.
 }
 ```
 
-**Hold response:**
+**Hold response (array — one hold per seat):**
 ```json
-{
-  "id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
-  "seatId": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
-  "eventId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-  "holderId": "user-session-abc123",
-  "expiresAt": "2026-07-15T19:10:00Z",
-  "createdAt": "2026-07-15T19:00:00Z",
-  "status": "ACTIVE"
-}
+[
+  {
+    "id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+    "seatId": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+    "eventId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "holderId": "user-session-abc123",
+    "expiresAt": "2026-07-15T19:10:00Z",
+    "createdAt": "2026-07-15T19:00:00Z",
+    "status": "ACTIVE"
+  }
+]
 ```
 
 **Hold statuses:** `ACTIVE`, `CONFIRMED`, `EXPIRED`, `RELEASED`

--- a/frontend/webpages/package-lock.json
+++ b/frontend/webpages/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.22.3",
         "react-scripts": "5.0.1",
+        "recharts": "^3.8.1",
         "web-vitals": "^2.1.4"
       }
     },
@@ -3407,6 +3408,42 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
@@ -3530,6 +3567,18 @@
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -3964,6 +4013,69 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "8.56.12",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
@@ -4260,6 +4372,12 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -6787,6 +6905,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -6879,6 +7118,12 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -7581,6 +7826,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -9750,6 +10005,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -14353,6 +14617,29 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -14518,6 +14805,52 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/recharts/node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/recursive-readdir": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
@@ -14541,6 +14874,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -14694,6 +15042,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -16446,6 +16800,12 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -16934,6 +17294,15 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -17006,6 +17375,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/w3c-hr-time": {

--- a/frontend/webpages/package.json
+++ b/frontend/webpages/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3",
     "react-scripts": "5.0.1",
+    "recharts": "^3.8.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/frontend/webpages/src/admin/components/EventsByVenueChart.js
+++ b/frontend/webpages/src/admin/components/EventsByVenueChart.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+
+function EventsByVenueChart({ data }) {
+  const chartData = data.map((v) => ({
+    name: v.venue.length > 15 ? v.venue.substring(0, 15) + '...' : v.venue,
+    count: v.count,
+  }));
+
+  return (
+    <Card sx={{ backgroundColor: 'background.paper', height: '100%' }}>
+      <CardContent>
+        <Typography variant="h6" sx={{ fontWeight: 600, mb: 1 }}>
+          Events by Venue
+        </Typography>
+        <ResponsiveContainer width="100%" height={320}>
+          <BarChart data={chartData}>
+            <XAxis dataKey="name" stroke="#b0b0b0" tick={{ fontSize: 12 }} />
+            <YAxis stroke="#b0b0b0" allowDecimals={false} />
+            <Tooltip contentStyle={{ backgroundColor: '#16213e', border: 'none', color: '#fff' }} />
+            <Bar dataKey="count" fill="#0f3460" radius={[4, 4, 0, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default EventsByVenueChart;

--- a/frontend/webpages/src/admin/components/HoldStatusChart.js
+++ b/frontend/webpages/src/admin/components/HoldStatusChart.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+
+const COLORS = { ACTIVE: '#2196f3', CONFIRMED: '#4caf50', EXPIRED: '#9e9e9e', RELEASED: '#ff9800' };
+
+function HoldStatusChart({ data }) {
+  const chartData = Object.entries(data).map(([name, value]) => ({ name, value }));
+
+  return (
+    <Card sx={{ backgroundColor: 'background.paper' }}>
+      <CardContent sx={{ p: 3 }}>
+        <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
+          Holds by Status
+        </Typography>
+        <div style={{ width: '100%', height: 300 }}>
+          <ResponsiveContainer>
+            <PieChart margin={{ top: 10, right: 10, bottom: 10, left: 10 }}>
+              <Pie data={chartData} dataKey="value" nameKey="name" cx="50%" cy="45%" outerRadius="70%" label={false}>
+                {chartData.map((entry) => (
+                  <Cell key={entry.name} fill={COLORS[entry.name] || '#8884d8'} />
+                ))}
+              </Pie>
+              <Tooltip />
+              <Legend wrapperStyle={{ paddingTop: 10 }} />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default HoldStatusChart;

--- a/frontend/webpages/src/admin/components/HoldsOverTimeChart.js
+++ b/frontend/webpages/src/admin/components/HoldsOverTimeChart.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts';
+
+function HoldsOverTimeChart({ data }) {
+  const chartData = data.map((d) => ({
+    date: d.date,
+    count: d.count,
+  }));
+
+  return (
+    <Card sx={{ backgroundColor: 'background.paper', height: '100%' }}>
+      <CardContent>
+        <Typography variant="h6" sx={{ fontWeight: 600, mb: 1 }}>
+          Holds Over Time (Last 30 Days)
+        </Typography>
+        <ResponsiveContainer width="100%" height={320}>
+          <LineChart data={chartData}>
+            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
+            <XAxis dataKey="date" stroke="#b0b0b0" tick={{ fontSize: 11 }} angle={-35} textAnchor="end" height={60} />
+            <YAxis stroke="#b0b0b0" allowDecimals={false} />
+            <Tooltip contentStyle={{ backgroundColor: '#16213e', border: 'none', color: '#fff' }} />
+            <Line type="monotone" dataKey="count" stroke="#e94560" strokeWidth={2} dot={{ r: 3 }} />
+          </LineChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default HoldsOverTimeChart;

--- a/frontend/webpages/src/admin/components/SeatStatusChart.js
+++ b/frontend/webpages/src/admin/components/SeatStatusChart.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+
+const COLORS = { AVAILABLE: '#4caf50', HELD: '#ff9800', BOOKED: '#e94560' };
+
+function SeatStatusChart({ data }) {
+  const chartData = Object.entries(data).map(([name, value]) => ({ name, value }));
+
+  return (
+    <Card sx={{ backgroundColor: 'background.paper' }}>
+      <CardContent sx={{ p: 3 }}>
+        <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
+          Seats by Status
+        </Typography>
+        <div style={{ width: '100%', height: 300 }}>
+          <ResponsiveContainer>
+            <PieChart margin={{ top: 10, right: 10, bottom: 10, left: 10 }}>
+              <Pie data={chartData} dataKey="value" nameKey="name" cx="50%" cy="45%" outerRadius="70%" label={false}>
+                {chartData.map((entry) => (
+                  <Cell key={entry.name} fill={COLORS[entry.name] || '#8884d8'} />
+                ))}
+              </Pie>
+              <Tooltip />
+              <Legend wrapperStyle={{ paddingTop: 10 }} />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default SeatStatusChart;

--- a/frontend/webpages/src/admin/components/TopEventsChart.js
+++ b/frontend/webpages/src/admin/components/TopEventsChart.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+
+function TopEventsChart({ data }) {
+  const chartData = data.map((e) => ({
+    name: e.eventTitle.length > 20 ? e.eventTitle.substring(0, 20) + '...' : e.eventTitle,
+    Available: e.available,
+    Held: e.held,
+    Booked: e.booked,
+  }));
+
+  const barHeight = Math.max(380, chartData.length * 50 + 80);
+
+  return (
+    <Card sx={{ backgroundColor: 'background.paper' }}>
+      <CardContent sx={{ p: 3 }}>
+        <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
+          Top Events by Bookings
+        </Typography>
+        <div style={{ width: '100%', height: barHeight }}>
+          <ResponsiveContainer>
+            <BarChart data={chartData} layout="vertical" margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
+              <XAxis type="number" stroke="#b0b0b0" allowDecimals={false} />
+              <YAxis type="category" dataKey="name" width={130} stroke="#b0b0b0" tick={{ fontSize: 12 }} />
+              <Tooltip contentStyle={{ backgroundColor: '#16213e', border: 'none', color: '#fff' }} />
+              <Legend />
+              <Bar dataKey="Booked" fill="#e94560" stackId="a" />
+              <Bar dataKey="Held" fill="#ff9800" stackId="a" />
+              <Bar dataKey="Available" fill="#4caf50" stackId="a" />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default TopEventsChart;

--- a/frontend/webpages/src/admin/components/UsersByRoleChart.js
+++ b/frontend/webpages/src/admin/components/UsersByRoleChart.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+
+const COLORS = { USER: '#2196f3', ADMIN: '#e94560' };
+
+function UsersByRoleChart({ data }) {
+  const chartData = Object.entries(data).map(([name, value]) => ({ name, value }));
+
+  return (
+    <Card sx={{ backgroundColor: 'background.paper' }}>
+      <CardContent sx={{ p: 3 }}>
+        <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
+          Users by Role
+        </Typography>
+        <div style={{ width: '100%', height: 300 }}>
+          <ResponsiveContainer>
+            <PieChart margin={{ top: 10, right: 10, bottom: 10, left: 10 }}>
+              <Pie data={chartData} dataKey="value" nameKey="name" cx="50%" cy="45%" outerRadius="70%" label={false}>
+                {chartData.map((entry) => (
+                  <Cell key={entry.name} fill={COLORS[entry.name] || '#8884d8'} />
+                ))}
+              </Pie>
+              <Tooltip />
+              <Legend wrapperStyle={{ paddingTop: 10 }} />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default UsersByRoleChart;

--- a/frontend/webpages/src/admin/pages/AdminDashboard.js
+++ b/frontend/webpages/src/admin/pages/AdminDashboard.js
@@ -2,67 +2,125 @@ import React, { useState, useEffect } from 'react';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
+import Alert from '@mui/material/Alert';
+import CircularProgress from '@mui/material/CircularProgress';
 import EventIcon from '@mui/icons-material/Event';
 import UpcomingIcon from '@mui/icons-material/CalendarMonth';
 import PeopleIcon from '@mui/icons-material/People';
+import ChairIcon from '@mui/icons-material/Chair';
+import ConfirmationNumberIcon from '@mui/icons-material/ConfirmationNumber';
+import PanToolIcon from '@mui/icons-material/PanTool';
+import PercentIcon from '@mui/icons-material/Percent';
 import StatsCard from '../components/StatsCard';
+import SeatStatusChart from '../components/SeatStatusChart';
+import HoldStatusChart from '../components/HoldStatusChart';
+import TopEventsChart from '../components/TopEventsChart';
+import HoldsOverTimeChart from '../components/HoldsOverTimeChart';
+import EventsByVenueChart from '../components/EventsByVenueChart';
+import UsersByRoleChart from '../components/UsersByRoleChart';
 import api from '../../api/client';
 
 function AdminDashboard() {
-  const [stats, setStats] = useState({ totalEvents: 0, upcomingEvents: 0, totalUsers: 0 });
+  const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
-    async function fetchStats() {
+    async function fetchAnalytics() {
       try {
-        const [allEvents, upcoming, users] = await Promise.all([
-          api.get('/api/events?size=1'),
-          api.get('/api/events?upcoming=true&size=1'),
-          api.get('/api/admin/users?size=1'),
-        ]);
-        setStats({
-          totalEvents: allEvents.totalElements || 0,
-          upcomingEvents: upcoming.totalElements || 0,
-          totalUsers: users.totalElements || 0,
-        });
+        const result = await api.get('/api/analytics/dashboard');
+        setData(result);
       } catch (err) {
-        console.error('Failed to fetch dashboard stats:', err);
+        console.error('Failed to fetch analytics:', err);
+        setError('Failed to load analytics data.');
       } finally {
         setLoading(false);
       }
     }
-    fetchStats();
+    fetchAnalytics();
   }, []);
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 400 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return <Alert severity="error" sx={{ mt: 2 }}>{error}</Alert>;
+  }
+
+  const { overview } = data;
 
   return (
     <Box>
       <Typography variant="h4" sx={{ mb: 3, fontWeight: 700 }}>
         Dashboard
       </Typography>
+
+      {/* Row 1: Overview Stats */}
+      <Grid container spacing={3} sx={{ mb: 3 }}>
+        <Grid item xs={12} sm={6} md={4} lg={4}>
+          <StatsCard title="Total Events" value={overview.totalEvents} icon={<EventIcon />} color="#e94560" />
+        </Grid>
+        <Grid item xs={12} sm={6} md={4} lg={4}>
+          <StatsCard title="Upcoming Events" value={overview.upcomingEvents} icon={<UpcomingIcon />} color="#0f3460" />
+        </Grid>
+        <Grid item xs={12} sm={6} md={4} lg={4}>
+          <StatsCard title="Total Users" value={overview.totalUsers} icon={<PeopleIcon />} color="#533483" />
+        </Grid>
+        <Grid item xs={12} sm={6} md={4} lg={4}>
+          <StatsCard title="Total Seats" value={overview.totalSeats} icon={<ChairIcon />} color="#2196f3" />
+        </Grid>
+        <Grid item xs={12} sm={6} md={4} lg={4}>
+          <StatsCard title="Booked Seats" value={overview.bookedSeats} icon={<ConfirmationNumberIcon />} color="#4caf50" />
+        </Grid>
+        <Grid item xs={12} sm={6} md={4} lg={4}>
+          <StatsCard title="Active Holds" value={overview.activeHolds} icon={<PanToolIcon />} color="#ff9800" />
+        </Grid>
+      </Grid>
+
+      {/* Row 2: Seat & Hold Status Pies */}
+      <Grid container spacing={3} sx={{ mb: 3 }}>
+        <Grid item xs={12} md={6}>
+          <SeatStatusChart data={data.seatsByStatus} />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <HoldStatusChart data={data.holdsByStatus} />
+        </Grid>
+      </Grid>
+
+      {/* Row 3: Top Events */}
+      <Grid container spacing={3} sx={{ mb: 3 }}>
+        <Grid item xs={12}>
+          <TopEventsChart data={data.topEventsByBookings} />
+        </Grid>
+      </Grid>
+
+      {/* Row 4: Holds Over Time & Events by Venue */}
+      <Grid container spacing={3} sx={{ mb: 3 }}>
+        <Grid item xs={12} md={7}>
+          <HoldsOverTimeChart data={data.holdsPerDay} />
+        </Grid>
+        <Grid item xs={12} md={5}>
+          <EventsByVenueChart data={data.eventsByVenue} />
+        </Grid>
+      </Grid>
+
+      {/* Row 5: Confirmation Rate & Users by Role */}
       <Grid container spacing={3}>
         <Grid item xs={12} sm={6} md={4}>
           <StatsCard
-            title="Total Events"
-            value={loading ? '...' : stats.totalEvents}
-            icon={<EventIcon />}
-            color="#e94560"
+            title="Hold Confirmation Rate"
+            value={`${data.holdConfirmationRate}%`}
+            icon={<PercentIcon />}
+            color="#4caf50"
           />
         </Grid>
-        <Grid item xs={12} sm={6} md={4}>
-          <StatsCard
-            title="Upcoming Events"
-            value={loading ? '...' : stats.upcomingEvents}
-            icon={<UpcomingIcon />}
-            color="#0f3460"
-          />
-        </Grid>
-        <Grid item xs={12} sm={6} md={4}>
-          <StatsCard
-            title="Total Users"
-            value={loading ? '...' : stats.totalUsers}
-            icon={<PeopleIcon />}
-            color="#533483"
-          />
+        <Grid item xs={12} sm={6} md={8}>
+          <UsersByRoleChart data={data.usersByRole} />
         </Grid>
       </Grid>
     </Box>


### PR DESCRIPTION
## Summary
- Adds Swagger/OpenAPI interactive docs at `/swagger-ui.html` with JWT Bearer auth support
- Adds `@Operation`, `@ApiResponse`, `@Tag`, `@Parameter` annotations to all 6 controllers
- Adds `@Schema` with example values to all DTOs for auto-generated example payloads
- Adds Javadoc to previously undocumented AuthController, AdminController, AnalyticsController
- Creates typed `AuthResponse` record replacing raw `Map<String, String>` in auth endpoints
- Adds full API contract doc in `docs/api-contract.md` covering all current endpoints and planned Orders/Tickets contracts

## Test plan
- [x] All 81 existing tests pass with no modifications
- [ ] Start backend, verify Swagger UI loads at `http://localhost:8080/swagger-ui.html`
- [ ] Test "Authorize" button with JWT from `/auth/login`
- [ ] Verify example payloads appear in Swagger UI for all endpoints
- [ ] Review `docs/api-contract.md` for accuracy

Closes #21