### PR TITLE
Build My Tickets MVP for purchased ticket retrieval and display

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -128,6 +128,11 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-redis</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <version>2.8.6</version>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/backend/src/main/java/com/fairtix/analytics/api/AnalyticsController.java
+++ b/backend/src/main/java/com/fairtix/analytics/api/AnalyticsController.java
@@ -1,24 +1,45 @@
 package com.fairtix.analytics.api;
 
 import com.fairtix.analytics.application.AnalyticsService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * Provides aggregate analytics for the admin dashboard.
+ *
+ * <p>Returns event counts, seat utilisation, hold metrics, and user breakdowns
+ * in a single response to minimise round-trips.
+ */
+@Tag(name = "Analytics", description = "Admin dashboard analytics")
 @RestController
 @RequestMapping("/api/analytics")
 public class AnalyticsController {
 
-  private final AnalyticsService analyticsService;
+    private final AnalyticsService analyticsService;
 
-  public AnalyticsController(AnalyticsService analyticsService) {
-    this.analyticsService = analyticsService;
-  }
+    public AnalyticsController(AnalyticsService analyticsService) {
+        this.analyticsService = analyticsService;
+    }
 
-  @PreAuthorize("hasRole('ADMIN')")
-  @GetMapping("/dashboard")
-  public AnalyticsResponse getDashboardAnalytics() {
-    return analyticsService.getDashboardAnalytics();
-  }
+    /**
+     * Returns a comprehensive analytics snapshot for the admin dashboard.
+     *
+     * @return aggregate stats covering events, seats, holds, and users
+     */
+    @Operation(summary = "Get dashboard analytics",
+            description = "Admin-only. Returns aggregate statistics for the admin dashboard.")
+    @ApiResponse(responseCode = "200", description = "Analytics snapshot")
+    @ApiResponse(responseCode = "403", description = "Not an admin")
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/dashboard")
+    public AnalyticsResponse getDashboardAnalytics() {
+        return analyticsService.getDashboardAnalytics();
+    }
 }

--- a/backend/src/main/java/com/fairtix/analytics/api/AnalyticsController.java
+++ b/backend/src/main/java/com/fairtix/analytics/api/AnalyticsController.java
@@ -1,0 +1,24 @@
+package com.fairtix.analytics.api;
+
+import com.fairtix.analytics.application.AnalyticsService;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/analytics")
+public class AnalyticsController {
+
+  private final AnalyticsService analyticsService;
+
+  public AnalyticsController(AnalyticsService analyticsService) {
+    this.analyticsService = analyticsService;
+  }
+
+  @PreAuthorize("hasRole('ADMIN')")
+  @GetMapping("/dashboard")
+  public AnalyticsResponse getDashboardAnalytics() {
+    return analyticsService.getDashboardAnalytics();
+  }
+}

--- a/backend/src/main/java/com/fairtix/analytics/api/AnalyticsResponse.java
+++ b/backend/src/main/java/com/fairtix/analytics/api/AnalyticsResponse.java
@@ -25,7 +25,8 @@ public record AnalyticsResponse(
             @Schema(example = "350") long totalUsers,
             @Schema(example = "5000") long totalSeats,
             @Schema(example = "1200") long bookedSeats,
-            @Schema(example = "85") long activeHolds) {
+            @Schema(example = "85") long activeHolds,
+            @Schema(example = "300") long soldSeats) {
     }
 
     @Schema(description = "Event count grouped by venue")
@@ -40,7 +41,8 @@ public record AnalyticsResponse(
             @Schema(example = "Summer Music Festival") String eventTitle,
             @Schema(example = "200") long available,
             @Schema(example = "50") long held,
-            @Schema(example = "150") long booked) {
+            @Schema(example = "150") long booked,
+            @Schema(example = "100") long sold) {
     }
 
     @Schema(description = "Hold count for a single day")

--- a/backend/src/main/java/com/fairtix/analytics/api/AnalyticsResponse.java
+++ b/backend/src/main/java/com/fairtix/analytics/api/AnalyticsResponse.java
@@ -13,7 +13,7 @@ public record AnalyticsResponse(
         Map<String, Long> seatsByStatus,
         List<EventInventory> topEventsByBookings,
         Map<String, Long> holdsByStatus,
-        @Schema(description = "Ratio of confirmed holds to total holds", example = "0.75")
+        @Schema(description = "Hold confirmation rate as a percentage (0-100)", example = "75.0")
         double holdConfirmationRate,
         List<DailyHoldCount> holdsPerDay,
         Map<String, Long> usersByRole) {

--- a/backend/src/main/java/com/fairtix/analytics/api/AnalyticsResponse.java
+++ b/backend/src/main/java/com/fairtix/analytics/api/AnalyticsResponse.java
@@ -1,32 +1,51 @@
 package com.fairtix.analytics.api;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+@Schema(description = "Aggregate analytics snapshot for the admin dashboard")
 public record AnalyticsResponse(
-    OverviewStats overview,
-    List<VenueCount> eventsByVenue,
-    Map<String, Long> seatsByStatus,
-    List<EventInventory> topEventsByBookings,
-    Map<String, Long> holdsByStatus,
-    double holdConfirmationRate,
-    List<DailyHoldCount> holdsPerDay,
-    Map<String, Long> usersByRole
-) {
+        OverviewStats overview,
+        List<VenueCount> eventsByVenue,
+        Map<String, Long> seatsByStatus,
+        List<EventInventory> topEventsByBookings,
+        Map<String, Long> holdsByStatus,
+        @Schema(description = "Ratio of confirmed holds to total holds", example = "0.75")
+        double holdConfirmationRate,
+        List<DailyHoldCount> holdsPerDay,
+        Map<String, Long> usersByRole) {
 
-  public record OverviewStats(
-      long totalEvents,
-      long upcomingEvents,
-      long totalUsers,
-      long totalSeats,
-      long bookedSeats,
-      long activeHolds
-  ) {}
+    @Schema(description = "High-level platform statistics")
+    public record OverviewStats(
+            @Schema(example = "42") long totalEvents,
+            @Schema(example = "18") long upcomingEvents,
+            @Schema(example = "350") long totalUsers,
+            @Schema(example = "5000") long totalSeats,
+            @Schema(example = "1200") long bookedSeats,
+            @Schema(example = "85") long activeHolds) {
+    }
 
-  public record VenueCount(String venue, long count) {}
+    @Schema(description = "Event count grouped by venue")
+    public record VenueCount(
+            @Schema(example = "Madison Square Garden") String venue,
+            @Schema(example = "12") long count) {
+    }
 
-  public record EventInventory(UUID eventId, String eventTitle, long available, long held, long booked) {}
+    @Schema(description = "Seat inventory breakdown for a single event")
+    public record EventInventory(
+            UUID eventId,
+            @Schema(example = "Summer Music Festival") String eventTitle,
+            @Schema(example = "200") long available,
+            @Schema(example = "50") long held,
+            @Schema(example = "150") long booked) {
+    }
 
-  public record DailyHoldCount(String date, long count) {}
+    @Schema(description = "Hold count for a single day")
+    public record DailyHoldCount(
+            @Schema(example = "2026-03-25") String date,
+            @Schema(example = "34") long count) {
+    }
 }

--- a/backend/src/main/java/com/fairtix/analytics/api/AnalyticsResponse.java
+++ b/backend/src/main/java/com/fairtix/analytics/api/AnalyticsResponse.java
@@ -1,0 +1,32 @@
+package com.fairtix.analytics.api;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public record AnalyticsResponse(
+    OverviewStats overview,
+    List<VenueCount> eventsByVenue,
+    Map<String, Long> seatsByStatus,
+    List<EventInventory> topEventsByBookings,
+    Map<String, Long> holdsByStatus,
+    double holdConfirmationRate,
+    List<DailyHoldCount> holdsPerDay,
+    Map<String, Long> usersByRole
+) {
+
+  public record OverviewStats(
+      long totalEvents,
+      long upcomingEvents,
+      long totalUsers,
+      long totalSeats,
+      long bookedSeats,
+      long activeHolds
+  ) {}
+
+  public record VenueCount(String venue, long count) {}
+
+  public record EventInventory(UUID eventId, String eventTitle, long available, long held, long booked) {}
+
+  public record DailyHoldCount(String date, long count) {}
+}

--- a/backend/src/main/java/com/fairtix/analytics/application/AnalyticsService.java
+++ b/backend/src/main/java/com/fairtix/analytics/application/AnalyticsService.java
@@ -66,8 +66,9 @@ public class AnalyticsService {
 
     long bookedSeats = seatsByStatus.getOrDefault("BOOKED", 0L);
     long activeHolds = seatsByStatus.getOrDefault("HELD", 0L);
+    long soldSeats = seatsByStatus.getOrDefault("SOLD", 0L);
 
-    return new OverviewStats(totalEvents, upcomingEvents, totalUsers, totalSeats, bookedSeats, activeHolds);
+    return new OverviewStats(totalEvents, upcomingEvents, totalUsers, totalSeats, bookedSeats, activeHolds, soldSeats);
   }
 
   private List<VenueCount> buildEventsByVenue() {
@@ -112,7 +113,8 @@ public class AnalyticsService {
               titleById.get(id),
               counts.getOrDefault("AVAILABLE", 0L),
               counts.getOrDefault("HELD", 0L),
-              counts.getOrDefault("BOOKED", 0L)
+              counts.getOrDefault("BOOKED", 0L),
+              counts.getOrDefault("SOLD", 0L)
           );
         })
         .sorted(Comparator.comparingLong(EventInventory::booked).reversed())

--- a/backend/src/main/java/com/fairtix/analytics/application/AnalyticsService.java
+++ b/backend/src/main/java/com/fairtix/analytics/application/AnalyticsService.java
@@ -1,0 +1,153 @@
+package com.fairtix.analytics.application;
+
+import com.fairtix.analytics.api.AnalyticsResponse;
+import com.fairtix.analytics.api.AnalyticsResponse.DailyHoldCount;
+import com.fairtix.analytics.api.AnalyticsResponse.EventInventory;
+import com.fairtix.analytics.api.AnalyticsResponse.OverviewStats;
+import com.fairtix.analytics.api.AnalyticsResponse.VenueCount;
+import com.fairtix.events.infrastructure.EventRepository;
+import com.fairtix.inventory.domain.HoldStatus;
+import com.fairtix.inventory.domain.SeatStatus;
+import com.fairtix.inventory.infrastructure.SeatHoldRepository;
+import com.fairtix.inventory.infrastructure.SeatRepository;
+import com.fairtix.users.infrastructure.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+
+@Service
+@Transactional(readOnly = true)
+public class AnalyticsService {
+
+  private final EventRepository eventRepository;
+  private final SeatRepository seatRepository;
+  private final SeatHoldRepository seatHoldRepository;
+  private final UserRepository userRepository;
+
+  public AnalyticsService(EventRepository eventRepository,
+                          SeatRepository seatRepository,
+                          SeatHoldRepository seatHoldRepository,
+                          UserRepository userRepository) {
+    this.eventRepository = eventRepository;
+    this.seatRepository = seatRepository;
+    this.seatHoldRepository = seatHoldRepository;
+    this.userRepository = userRepository;
+  }
+
+  public AnalyticsResponse getDashboardAnalytics() {
+    OverviewStats overview = buildOverview();
+    List<VenueCount> eventsByVenue = buildEventsByVenue();
+    Map<String, Long> seatsByStatus = buildSeatsByStatus();
+    List<EventInventory> topEvents = buildTopEventsByBookings();
+    Map<String, Long> holdsByStatus = buildHoldsByStatus();
+    double holdConfirmationRate = computeHoldConfirmationRate(holdsByStatus);
+    List<DailyHoldCount> holdsPerDay = buildHoldsPerDay();
+    Map<String, Long> usersByRole = buildUsersByRole();
+
+    return new AnalyticsResponse(
+        overview, eventsByVenue, seatsByStatus, topEvents,
+        holdsByStatus, holdConfirmationRate, holdsPerDay, usersByRole
+    );
+  }
+
+  private OverviewStats buildOverview() {
+    long totalEvents = eventRepository.count();
+    long upcomingEvents = eventRepository.countByStartTimeAfter(Instant.now());
+    long totalUsers = userRepository.count();
+    long totalSeats = seatRepository.count();
+
+    Map<String, Long> seatCounts = buildSeatsByStatus();
+    long bookedSeats = seatCounts.getOrDefault("BOOKED", 0L);
+    long activeHolds = seatCounts.getOrDefault("HELD", 0L);
+
+    return new OverviewStats(totalEvents, upcomingEvents, totalUsers, totalSeats, bookedSeats, activeHolds);
+  }
+
+  private List<VenueCount> buildEventsByVenue() {
+    return eventRepository.countByVenueGrouped().stream()
+        .map(row -> new VenueCount((String) row[0], (Long) row[1]))
+        .sorted(Comparator.comparingLong(VenueCount::count).reversed())
+        .toList();
+  }
+
+  private Map<String, Long> buildSeatsByStatus() {
+    Map<String, Long> map = new LinkedHashMap<>();
+    for (SeatStatus status : SeatStatus.values()) {
+      map.put(status.name(), 0L);
+    }
+    for (Object[] row : seatRepository.countByStatusGrouped()) {
+      map.put(((SeatStatus) row[0]).name(), (Long) row[1]);
+    }
+    return map;
+  }
+
+  private List<EventInventory> buildTopEventsByBookings() {
+    Map<UUID, String> titleById = new HashMap<>();
+    Map<UUID, Map<String, Long>> statusCounts = new HashMap<>();
+
+    for (Object[] row : seatRepository.countByEventAndStatus()) {
+      UUID eventId = (UUID) row[0];
+      String title = (String) row[1];
+      SeatStatus status = (SeatStatus) row[2];
+      long count = (Long) row[3];
+
+      titleById.put(eventId, title);
+      statusCounts.computeIfAbsent(eventId, k -> new HashMap<>())
+          .put(status.name(), count);
+    }
+
+    return statusCounts.entrySet().stream()
+        .map(e -> {
+          UUID id = e.getKey();
+          Map<String, Long> counts = e.getValue();
+          return new EventInventory(
+              id,
+              titleById.get(id),
+              counts.getOrDefault("AVAILABLE", 0L),
+              counts.getOrDefault("HELD", 0L),
+              counts.getOrDefault("BOOKED", 0L)
+          );
+        })
+        .sorted(Comparator.comparingLong(EventInventory::booked).reversed())
+        .limit(10)
+        .toList();
+  }
+
+  private Map<String, Long> buildHoldsByStatus() {
+    Map<String, Long> map = new LinkedHashMap<>();
+    for (HoldStatus status : HoldStatus.values()) {
+      map.put(status.name(), 0L);
+    }
+    for (Object[] row : seatHoldRepository.countByStatusGrouped()) {
+      map.put(((HoldStatus) row[0]).name(), (Long) row[1]);
+    }
+    return map;
+  }
+
+  private double computeHoldConfirmationRate(Map<String, Long> holdsByStatus) {
+    long confirmed = holdsByStatus.getOrDefault("CONFIRMED", 0L);
+    long expired = holdsByStatus.getOrDefault("EXPIRED", 0L);
+    long released = holdsByStatus.getOrDefault("RELEASED", 0L);
+    long completed = confirmed + expired + released;
+    if (completed == 0) return 0.0;
+    return Math.round((double) confirmed / completed * 1000.0) / 10.0;
+  }
+
+  private List<DailyHoldCount> buildHoldsPerDay() {
+    Instant since = Instant.now().minus(30, ChronoUnit.DAYS);
+    return seatHoldRepository.countHoldsPerDay(since).stream()
+        .map(row -> new DailyHoldCount(row[0].toString(), ((Number) row[1]).longValue()))
+        .toList();
+  }
+
+  private Map<String, Long> buildUsersByRole() {
+    Map<String, Long> map = new LinkedHashMap<>();
+    for (Object[] row : userRepository.countByRoleGrouped()) {
+      map.put(row[0].toString(), (Long) row[1]);
+    }
+    return map;
+  }
+}

--- a/backend/src/main/java/com/fairtix/analytics/application/AnalyticsService.java
+++ b/backend/src/main/java/com/fairtix/analytics/application/AnalyticsService.java
@@ -16,7 +16,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 @Service
 @Transactional(readOnly = true)
@@ -38,9 +43,9 @@ public class AnalyticsService {
   }
 
   public AnalyticsResponse getDashboardAnalytics() {
-    OverviewStats overview = buildOverview();
-    List<VenueCount> eventsByVenue = buildEventsByVenue();
     Map<String, Long> seatsByStatus = buildSeatsByStatus();
+    OverviewStats overview = buildOverview(seatsByStatus);
+    List<VenueCount> eventsByVenue = buildEventsByVenue();
     List<EventInventory> topEvents = buildTopEventsByBookings();
     Map<String, Long> holdsByStatus = buildHoldsByStatus();
     double holdConfirmationRate = computeHoldConfirmationRate(holdsByStatus);
@@ -53,15 +58,14 @@ public class AnalyticsService {
     );
   }
 
-  private OverviewStats buildOverview() {
+  private OverviewStats buildOverview(Map<String, Long> seatsByStatus) {
     long totalEvents = eventRepository.count();
     long upcomingEvents = eventRepository.countByStartTimeAfter(Instant.now());
     long totalUsers = userRepository.count();
     long totalSeats = seatRepository.count();
 
-    Map<String, Long> seatCounts = buildSeatsByStatus();
-    long bookedSeats = seatCounts.getOrDefault("BOOKED", 0L);
-    long activeHolds = seatCounts.getOrDefault("HELD", 0L);
+    long bookedSeats = seatsByStatus.getOrDefault("BOOKED", 0L);
+    long activeHolds = seatsByStatus.getOrDefault("HELD", 0L);
 
     return new OverviewStats(totalEvents, upcomingEvents, totalUsers, totalSeats, bookedSeats, activeHolds);
   }

--- a/backend/src/main/java/com/fairtix/auth/api/AuthController.java
+++ b/backend/src/main/java/com/fairtix/auth/api/AuthController.java
@@ -1,33 +1,65 @@
 package com.fairtix.auth.api;
 
-import java.util.Map;
-
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.fairtix.auth.application.AuthService;
+import com.fairtix.users.dto.AuthResponse;
 import com.fairtix.users.dto.LoginRequest;
 import com.fairtix.users.dto.RegisterRequest;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * Handles user authentication — registration and login.
+ *
+ * <p>All endpoints are public and return a signed JWT on success.
+ */
+@Tag(name = "Auth", description = "Registration and login")
 @RestController
 @RequestMapping("/auth")
 public class AuthController {
 
-  private final AuthService service;
+    private final AuthService service;
 
-  public AuthController(AuthService service) {
-    this.service = service;
-  }
+    public AuthController(AuthService service) {
+        this.service = service;
+    }
 
-  @PostMapping("/register")
-  public Map<String, String> register(@RequestBody RegisterRequest request) {
-    return Map.of("token", service.register(request));
-  }
+    /**
+     * Registers a new user account.
+     *
+     * @param request email and password for the new account
+     * @return a signed JWT for the newly created user
+     */
+    @Operation(summary = "Register a new user",
+            description = "Creates a user account and returns a JWT token.")
+    @ApiResponse(responseCode = "200", description = "Registration successful")
+    @ApiResponse(responseCode = "409", description = "Email already in use")
+    @SecurityRequirements
+    @PostMapping("/register")
+    public AuthResponse register(@RequestBody RegisterRequest request) {
+        return new AuthResponse(service.register(request));
+    }
 
-  @PostMapping("/login")
-  public Map<String, String> login(@RequestBody LoginRequest request) {
-    return Map.of("token", service.login(request));
-  }
+    /**
+     * Authenticates an existing user.
+     *
+     * @param request email and password credentials
+     * @return a signed JWT for the authenticated user
+     */
+    @Operation(summary = "Log in",
+            description = "Authenticates with email/password and returns a JWT token.")
+    @ApiResponse(responseCode = "200", description = "Login successful")
+    @ApiResponse(responseCode = "401", description = "Invalid credentials")
+    @SecurityRequirements
+    @PostMapping("/login")
+    public AuthResponse login(@RequestBody LoginRequest request) {
+        return new AuthResponse(service.login(request));
+    }
 }

--- a/backend/src/main/java/com/fairtix/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/fairtix/config/GlobalExceptionHandler.java
@@ -3,7 +3,11 @@ package com.fairtix.config;
 import com.fairtix.common.ResourceNotFoundException;
 import com.fairtix.inventory.application.SeatHoldConflictException;
 import com.fairtix.inventory.application.SeatHoldNotFoundException;
+import com.fairtix.orders.application.OrderNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -31,6 +35,8 @@ import java.util.Map;
  */
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+  private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
   @ExceptionHandler(SeatHoldNotFoundException.class)
   public ResponseEntity<Map<String, Object>> handleNotFound(
@@ -87,10 +93,32 @@ public class GlobalExceptionHandler {
     return error(HttpStatus.FORBIDDEN, "FORBIDDEN", "Access denied", req);
   }
 
+  @ExceptionHandler(OrderNotFoundException.class)
+  public ResponseEntity<Map<String, Object>> handleOrderNotFound(
+      OrderNotFoundException ex, HttpServletRequest req) {
+    return error(HttpStatus.NOT_FOUND, "ORDER_NOT_FOUND", ex.getMessage(), req);
+  }
+
   @ExceptionHandler(ResourceNotFoundException.class)
   public ResponseEntity<Map<String, Object>> handleResourceNotFound(
       ResourceNotFoundException ex, HttpServletRequest req) {
     return error(HttpStatus.NOT_FOUND, "RESOURCE_NOT_FOUND", ex.getMessage(), req);
+  }
+
+  @ExceptionHandler(DataIntegrityViolationException.class)
+  public ResponseEntity<Map<String, Object>> handleDataIntegrity(
+      DataIntegrityViolationException ex, HttpServletRequest req) {
+    log.error("Data integrity violation on {}: {}", req.getRequestURI(), ex.getMessage());
+    return error(HttpStatus.CONFLICT, "DATA_CONFLICT",
+        "The request conflicts with the current state of the data", req);
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<Map<String, Object>> handleUnexpected(
+      Exception ex, HttpServletRequest req) {
+    log.error("Unhandled exception on {}", req.getRequestURI(), ex);
+    return error(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR",
+        "An unexpected error occurred", req);
   }
 
   // -------------------------------------------------------------------------

--- a/backend/src/main/java/com/fairtix/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/fairtix/config/OpenApiConfig.java
@@ -1,0 +1,32 @@
+package com.fairtix.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI fairtixOpenAPI() {
+        String schemeName = "bearerAuth";
+        return new OpenAPI()
+                .info(new Info()
+                        .title("FairTix API")
+                        .version("1.0.0")
+                        .description("Fair ticketing platform API for event management, "
+                                + "seat inventory, holds, and administration."))
+                .addSecurityItem(new SecurityRequirement().addList(schemeName))
+                .components(new Components()
+                        .addSecuritySchemes(schemeName, new SecurityScheme()
+                                .name(schemeName)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .description("Paste a JWT obtained from POST /auth/login")));
+    }
+}

--- a/backend/src/main/java/com/fairtix/config/RedisConfig.java
+++ b/backend/src/main/java/com/fairtix/config/RedisConfig.java
@@ -4,6 +4,7 @@ import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -17,6 +18,7 @@ public class RedisConfig {
     private int redisPort;
 
     @Bean
+    @ConditionalOnMissingBean(RedissonClient.class)
     public RedissonClient redissonClient() {
         Config config = new Config();
         config.useSingleServer()

--- a/backend/src/main/java/com/fairtix/config/RedisConfig.java
+++ b/backend/src/main/java/com/fairtix/config/RedisConfig.java
@@ -3,17 +3,24 @@ package com.fairtix.config;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class RedisConfig {
 
+    @Value("${spring.redis.host:localhost}")
+    private String redisHost;
+
+    @Value("${spring.redis.port:6379}")
+    private int redisPort;
+
     @Bean
     public RedissonClient redissonClient() {
         Config config = new Config();
         config.useSingleServer()
-              .setAddress("redis://127.0.0.1:6379");
+              .setAddress("redis://" + redisHost + ":" + redisPort);
 
         return Redisson.create(config);
     }

--- a/backend/src/main/java/com/fairtix/config/SecurityConfig.java
+++ b/backend/src/main/java/com/fairtix/config/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
         .csrf(csrf -> csrf.disable())
         .authorizeHttpRequests(auth -> auth
             .requestMatchers("/auth/**").permitAll()
+            .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
             .requestMatchers(HttpMethod.GET, "/api/events/**").permitAll()
             .anyRequest().authenticated())
         .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/backend/src/main/java/com/fairtix/events/api/EventController.java
+++ b/backend/src/main/java/com/fairtix/events/api/EventController.java
@@ -12,103 +12,133 @@ import com.fairtix.events.dto.CreateEventRequest;
 import com.fairtix.events.dto.UpdateEventRequest;
 import com.fairtix.events.dto.EventResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.security.PermitAll;
 import jakarta.validation.Valid;
 
 import java.util.UUID;
 
+/**
+ * CRUD operations for events.
+ *
+ * <p>Read endpoints are public; create, update, and delete require the ADMIN role.
+ */
+@Tag(name = "Events", description = "Event management")
 @RestController
 @RequestMapping("/api/events")
 public class EventController {
 
-  private final EventService service;
+    private final EventService service;
 
-  public EventController(EventService service) {
-    this.service = service;
-  }
+    public EventController(EventService service) {
+        this.service = service;
+    }
 
-  /**
-   * Creates a new event.
-   *
-   * Accepts a JSON request body containing event details
-   * 
-   * @param request the requested event as a json payload
-   * @return the newly created event
-   */
-  @PreAuthorize("hasRole('ADMIN')")
-  @PostMapping
-  @ResponseStatus(HttpStatus.CREATED)
-  public EventResponse createEvent(@Valid @RequestBody CreateEventRequest request) {
-    Event event = service.createEvent(
-        request.title(),
-        request.startTime(),
-        request.venue());
-    return EventResponse.from(event);
-  }
+    /**
+     * Creates a new event.
+     *
+     * Accepts a JSON request body containing event details
+     *
+     * @param request the requested event as a json payload
+     * @return the newly created event
+     */
+    @Operation(summary = "Create an event", description = "Admin-only. Creates a new event.")
+    @ApiResponse(responseCode = "201", description = "Event created")
+    @ApiResponse(responseCode = "400", description = "Validation error")
+    @ApiResponse(responseCode = "403", description = "Not an admin")
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public EventResponse createEvent(@Valid @RequestBody CreateEventRequest request) {
+        Event event = service.createEvent(
+                request.title(),
+                request.startTime(),
+                request.venue());
+        return EventResponse.from(event);
+    }
 
-  /**
-   * Takes details about the types of events requested and returns a page of that
-   * type of event
-   *
-   * @param venueName the name of the venue
-   * @param title     the title of the event
-   * @param upcoming  whether or not to only display upcoming events
-   *                  (true by default)
-   * @param page      the page number
-   * @param size      the number of items per page
-   * @return the requested page
-   */
-  @PermitAll
-  @GetMapping
-  public Page<EventResponse> search(
-      @RequestParam(required = false) String venueName,
-      @RequestParam(required = false) String title,
-      @RequestParam(required = false) Boolean upcoming,
-      @RequestParam(defaultValue = "0") int page,
-      @RequestParam(defaultValue = "20") int size) {
+    /**
+     * Takes details about the types of events requested and returns a page of that
+     * type of event
+     *
+     * @param venueName the name of the venue
+     * @param title     the title of the event
+     * @param upcoming  whether or not to only display upcoming events
+     *                  (true by default)
+     * @param page      the page number
+     * @param size      the number of items per page
+     * @return the requested page
+     */
+    @Operation(summary = "Search events",
+            description = "Public. Returns a paginated list of events, optionally filtered.")
+    @ApiResponse(responseCode = "200", description = "Page of matching events")
+    @SecurityRequirements
+    @PermitAll
+    @GetMapping
+    public Page<EventResponse> search(
+            @Parameter(description = "Filter by venue name") @RequestParam(required = false) String venueName,
+            @Parameter(description = "Filter by title (contains)") @RequestParam(required = false) String title,
+            @Parameter(description = "Only future events") @RequestParam(required = false) Boolean upcoming,
+            @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size (max 100)") @RequestParam(defaultValue = "20") int size) {
 
-    Page<Event> events = service.search(venueName, title, upcoming, PageRequest.of(page, Math.min(size, 100)));
-    return events.map(EventResponse::from);
-  }
+        Page<Event> events = service.search(venueName, title, upcoming, PageRequest.of(page, Math.min(size, 100)));
+        return events.map(EventResponse::from);
+    }
 
-  /**
-   * Gets a specific event based on its id
-   *
-   * @param id the id of the event
-   * @return the requested event
-   */
-  @PermitAll
-  @GetMapping("/{id}")
-  public EventResponse getEvent(@PathVariable UUID id) {
-    return EventResponse.from(service.getEvent(id));
-  }
+    /**
+     * Gets a specific event based on its id
+     *
+     * @param id the id of the event
+     * @return the requested event
+     */
+    @Operation(summary = "Get event by ID", description = "Public. Returns a single event.")
+    @ApiResponse(responseCode = "200", description = "Event found")
+    @ApiResponse(responseCode = "404", description = "Event not found")
+    @SecurityRequirements
+    @PermitAll
+    @GetMapping("/{id}")
+    public EventResponse getEvent(@PathVariable UUID id) {
+        return EventResponse.from(service.getEvent(id));
+    }
 
-  /**
-   * Updates the title or start time of an event
-   *
-   * @param id      the id of the event
-   * @param request an {@link UpdateEventRequest} containing the updated details
-   *                of the event
-   * @return an {@link EventResponse} containing the newly updated event
-   */
-  @PreAuthorize("hasRole('ADMIN')")
-  @PutMapping("/{id}")
-  public EventResponse update(
-      @PathVariable UUID id,
-      @Valid @RequestBody UpdateEventRequest request) {
-    Event updated = service.update(id, request);
-    return EventResponse.from(updated);
-  }
+    /**
+     * Updates the title or start time of an event
+     *
+     * @param id      the id of the event
+     * @param request an {@link UpdateEventRequest} containing the updated details
+     *                of the event
+     * @return an {@link EventResponse} containing the newly updated event
+     */
+    @Operation(summary = "Update an event", description = "Admin-only. Updates title and/or start time.")
+    @ApiResponse(responseCode = "200", description = "Event updated")
+    @ApiResponse(responseCode = "400", description = "Validation error")
+    @ApiResponse(responseCode = "404", description = "Event not found")
+    @PreAuthorize("hasRole('ADMIN')")
+    @PutMapping("/{id}")
+    public EventResponse update(
+            @PathVariable UUID id,
+            @Valid @RequestBody UpdateEventRequest request) {
+        Event updated = service.update(id, request);
+        return EventResponse.from(updated);
+    }
 
-  /**
-   * Deletes the requested event
-   *
-   * @param id the UUID id of the event
-   */
-  @PreAuthorize("hasRole('ADMIN')")
-  @DeleteMapping("/{id}")
-  @ResponseStatus(HttpStatus.NO_CONTENT)
-  public void delete(@PathVariable UUID id) {
-    service.delete(id);
-  }
+    /**
+     * Deletes the requested event
+     *
+     * @param id the UUID id of the event
+     */
+    @Operation(summary = "Delete an event", description = "Admin-only. Permanently deletes an event.")
+    @ApiResponse(responseCode = "204", description = "Event deleted")
+    @ApiResponse(responseCode = "404", description = "Event not found")
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable UUID id) {
+        service.delete(id);
+    }
 }

--- a/backend/src/main/java/com/fairtix/events/dto/CreateEventRequest.java
+++ b/backend/src/main/java/com/fairtix/events/dto/CreateEventRequest.java
@@ -2,18 +2,23 @@ package com.fairtix.events.dto;
 
 import java.time.Instant;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 /**
  * Requests / Creates payload for creating a new event
- * 
+ *
  * @param title     the event title
  * @param startTime the event start time in UTC (ISO-8601)
  * @param venue     the venue name
  */
+@Schema(description = "Payload for creating a new event")
 public record CreateEventRequest(
-                @NotBlank String title,
-                @NotNull Instant startTime,
-                @NotBlank String venue) {
+        @Schema(description = "Event title", example = "Summer Music Festival")
+        @NotBlank String title,
+        @Schema(description = "Event start time in UTC (ISO-8601)", example = "2026-07-15T19:00:00Z")
+        @NotNull Instant startTime,
+        @Schema(description = "Venue name", example = "Madison Square Garden")
+        @NotBlank String venue) {
 }

--- a/backend/src/main/java/com/fairtix/events/dto/EventResponse.java
+++ b/backend/src/main/java/com/fairtix/events/dto/EventResponse.java
@@ -5,33 +5,40 @@ import java.util.UUID;
 
 import com.fairtix.events.domain.Event;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * Response payload for an event
  *
  * Returned by event api endpoints
- * 
+ *
  * @param id        the unique id of the event
  * @param title     the event title
  * @param startTime the event start time in UTC (ISO-8601)
  * @param venue     the name of the venue
  */
+@Schema(description = "Event details")
 public record EventResponse(
-    UUID id,
-    String title,
-    Instant startTime,
-    String venue) {
+        @Schema(description = "Event ID", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+        UUID id,
+        @Schema(description = "Event title", example = "Summer Music Festival")
+        String title,
+        @Schema(description = "Start time in UTC", example = "2026-07-15T19:00:00Z")
+        Instant startTime,
+        @Schema(description = "Venue name", example = "Madison Square Garden")
+        String venue) {
 
-  /**
-   * Maps an {@link Event} object to an API response.
-   *
-   * @param event the event entity
-   * @return the corresponding {@link EventResponse}
-   */
-  public static EventResponse from(Event event) {
-    return new EventResponse(
-        event.getId(),
-        event.getTitle(),
-        event.getStartTime(),
-        event.getVenue());
-  }
+    /**
+     * Maps an {@link Event} object to an API response.
+     *
+     * @param event the event entity
+     * @return the corresponding {@link EventResponse}
+     */
+    public static EventResponse from(Event event) {
+        return new EventResponse(
+                event.getId(),
+                event.getTitle(),
+                event.getStartTime(),
+                event.getVenue());
+    }
 }

--- a/backend/src/main/java/com/fairtix/events/dto/UpdateEventRequest.java
+++ b/backend/src/main/java/com/fairtix/events/dto/UpdateEventRequest.java
@@ -2,11 +2,15 @@ package com.fairtix.events.dto;
 
 import java.time.Instant;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "Payload for updating an event")
 public record UpdateEventRequest(
+        @Schema(description = "Updated event title", example = "Summer Music Festival 2026")
         @NotBlank @Size(max = 500) String title,
+        @Schema(description = "Updated start time in UTC", example = "2026-07-16T20:00:00Z")
         @NotNull Instant startTime) {
 }

--- a/backend/src/main/java/com/fairtix/events/infrastructure/EventRepository.java
+++ b/backend/src/main/java/com/fairtix/events/infrastructure/EventRepository.java
@@ -3,9 +3,17 @@ package com.fairtix.events.infrastructure;
 import com.fairtix.events.domain.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 public interface EventRepository extends JpaRepository<Event, UUID>,
     JpaSpecificationExecutor<Event> {
+
+  long countByStartTimeAfter(Instant now);
+
+  @Query("SELECT e.venue, COUNT(e) FROM Event e GROUP BY e.venue")
+  List<Object[]> countByVenueGrouped();
 }

--- a/backend/src/main/java/com/fairtix/inventory/api/SeatController.java
+++ b/backend/src/main/java/com/fairtix/inventory/api/SeatController.java
@@ -4,6 +4,11 @@ import com.fairtix.inventory.application.SeatService;
 import com.fairtix.inventory.dto.CreateSeatRequest;
 import com.fairtix.inventory.dto.SeatResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.security.PermitAll;
 
 import org.springframework.http.HttpStatus;
@@ -16,58 +21,72 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Manages the seat inventory for events.
+ *
+ * <p>Admins can create seats; anyone can list them.
+ */
+@Tag(name = "Seats", description = "Seat inventory for events")
 @RestController
 @RequestMapping("/api/events/{eventId}/seats")
 public class SeatController {
 
-  private static final Logger log = LoggerFactory.getLogger(SeatController.class);
-  private final SeatService seatService;
+    private static final Logger log = LoggerFactory.getLogger(SeatController.class);
+    private final SeatService seatService;
 
-  public SeatController(SeatService seatService) {
-    this.seatService = seatService;
-  }
+    public SeatController(SeatService seatService) {
+        this.seatService = seatService;
+    }
 
-  /**
-   * Creates a single seat for an event.
-   * Intended for dev/testing — seed seats before placing holds.
-   *
-   * @param eventId the owning event
-   * @param request the seat details
-   * @return the created seat
-   */
-  @PreAuthorize("hasRole('ADMIN')")
-  @PostMapping
-  @ResponseStatus(HttpStatus.CREATED)
-  public SeatResponse createSeat(
-      @PathVariable UUID eventId,
-      @RequestBody CreateSeatRequest request) {
+    /**
+     * Creates a single seat for an event.
+     * Intended for dev/testing — seed seats before placing holds.
+     *
+     * @param eventId the owning event
+     * @param request the seat details
+     * @return the created seat
+     */
+    @Operation(summary = "Create a seat", description = "Admin-only. Adds a seat to an event's inventory.")
+    @ApiResponse(responseCode = "201", description = "Seat created")
+    @ApiResponse(responseCode = "404", description = "Event not found")
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public SeatResponse createSeat(
+            @PathVariable UUID eventId,
+            @RequestBody CreateSeatRequest request) {
 
-    log.info("Request to create seat for event {} section={} row={} seat={}",
-            eventId, request.section(), request.rowLabel(), request.seatNumber());
+        log.info("Request to create seat for event {} section={} row={} seat={}",
+                eventId, request.section(), request.rowLabel(), request.seatNumber());
 
-    return SeatResponse.from(
-        seatService.createSeat(eventId, request.section(), request.rowLabel(), request.seatNumber()));
-  }
+        return SeatResponse.from(
+                seatService.createSeat(eventId, request.section(), request.rowLabel(), request.seatNumber()));
+    }
 
-  /**
-   * Lists seats for an event, optionally filtered to available seats only.
-   *
-   * @param eventId       the event id
-   * @param availableOnly when {@code true} only AVAILABLE seats are returned
-   * @return list of matching seats
-   */
-  @PermitAll
-  @GetMapping
-  public List<SeatResponse> getSeats(
-      @PathVariable UUID eventId,
-      @RequestParam(required = false, defaultValue = "false") boolean availableOnly) {
+    /**
+     * Lists seats for an event, optionally filtered to available seats only.
+     *
+     * @param eventId       the event id
+     * @param availableOnly when {@code true} only AVAILABLE seats are returned
+     * @return list of matching seats
+     */
+    @Operation(summary = "List seats for an event",
+            description = "Public. Returns all seats, optionally filtered to available only.")
+    @ApiResponse(responseCode = "200", description = "List of seats")
+    @SecurityRequirements
+    @PermitAll
+    @GetMapping
+    public List<SeatResponse> getSeats(
+            @PathVariable UUID eventId,
+            @Parameter(description = "Return only AVAILABLE seats")
+            @RequestParam(required = false, defaultValue = "false") boolean availableOnly) {
 
-    log.info("Request to fetch seats for event {} (availableOnly={})",
-            eventId, availableOnly);
+        log.info("Request to fetch seats for event {} (availableOnly={})",
+                eventId, availableOnly);
 
-    var seats = availableOnly
-        ? seatService.getAvailableSeatsForEvent(eventId)
-        : seatService.getSeatsForEvent(eventId);
-    return seats.stream().map(SeatResponse::from).toList();
-  }
+        var seats = availableOnly
+                ? seatService.getAvailableSeatsForEvent(eventId)
+                : seatService.getSeatsForEvent(eventId);
+        return seats.stream().map(SeatResponse::from).toList();
+    }
 }

--- a/backend/src/main/java/com/fairtix/inventory/api/SeatHoldController.java
+++ b/backend/src/main/java/com/fairtix/inventory/api/SeatHoldController.java
@@ -5,6 +5,10 @@ import com.fairtix.inventory.domain.HoldStatus;
 import com.fairtix.inventory.dto.CreateHoldRequest;
 import com.fairtix.inventory.dto.SeatHoldResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.security.PermitAll;
 import jakarta.validation.Valid;
 
@@ -15,97 +19,136 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * Manages temporary seat holds and their lifecycle (create → confirm / release).
+ *
+ * <p>Holds expire automatically after a configurable duration. Confirm and release
+ * operations are idempotent — safe to retry without side effects.
+ */
+@Tag(name = "Holds", description = "Seat hold lifecycle")
 @RestController
 public class SeatHoldController {
 
-  private final SeatHoldService seatHoldService;
+    private final SeatHoldService seatHoldService;
 
-  public SeatHoldController(SeatHoldService seatHoldService) {
-    this.seatHoldService = seatHoldService;
-  }
+    public SeatHoldController(SeatHoldService seatHoldService) {
+        this.seatHoldService = seatHoldService;
+    }
 
-  /**
-   * Places a hold on one or more seats for an event.
-   *
-   * POST /api/events/{eventId}/holds
-   * Body: { "seatIds": ["..."], "holderId": "...", "durationMinutes": 10 }
-   *
-   * @return 201 Created with the list of created holds
-   */
-  @PreAuthorize("isAuthenticated()")
-  @PostMapping("/api/events/{eventId}/holds")
-  @ResponseStatus(HttpStatus.CREATED)
-  public List<SeatHoldResponse> createHold(
-      @PathVariable UUID eventId,
-      @Valid @RequestBody CreateHoldRequest request) {
-    return seatHoldService
-        .createHold(eventId, request.seatIds(), request.holderId(), request.durationMinutes())
-        .stream()
-        .map(SeatHoldResponse::from)
-        .toList();
-  }
+    /**
+     * Places a hold on one or more seats for an event.
+     *
+     * POST /api/events/{eventId}/holds
+     * Body: { "seatIds": ["..."], "holderId": "...", "durationMinutes": 10 }
+     *
+     * @param eventId the event whose seats to hold
+     * @param request seat IDs, holder identifier, and optional duration
+     * @return 201 Created with the list of created holds
+     */
+    @Operation(summary = "Create a seat hold",
+            description = "Authenticated. Temporarily reserves 1–10 seats for the holder.")
+    @ApiResponse(responseCode = "201", description = "Holds created")
+    @ApiResponse(responseCode = "400", description = "Validation error")
+    @ApiResponse(responseCode = "409", description = "One or more seats not available")
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/api/events/{eventId}/holds")
+    @ResponseStatus(HttpStatus.CREATED)
+    public List<SeatHoldResponse> createHold(
+            @PathVariable UUID eventId,
+            @Valid @RequestBody CreateHoldRequest request) {
+        return seatHoldService
+                .createHold(eventId, request.seatIds(), request.holderId(), request.durationMinutes())
+                .stream()
+                .map(SeatHoldResponse::from)
+                .toList();
+    }
 
-  /**
-   * Lists holds for a given holder, optionally filtered by status.
-   *
-   * GET /api/holds?holderId=...&status=ACTIVE
-   *
-   * @return 200 OK with the matching holds (empty list if none)
-   */
-  @GetMapping("/api/holds")
-  public List<SeatHoldResponse> listHolds(
-      @RequestParam String holderId,
-      @RequestParam(defaultValue = "ACTIVE") HoldStatus status) {
-    return seatHoldService.listHolds(holderId, status)
-        .stream()
-        .map(SeatHoldResponse::from)
-        .toList();
-  }
+    /**
+     * Lists holds for a given holder, optionally filtered by status.
+     *
+     * GET /api/holds?holderId=...&amp;status=ACTIVE
+     *
+     * @param holderId the holder's identifier
+     * @param status   hold status filter (defaults to ACTIVE)
+     * @return 200 OK with the matching holds (empty list if none)
+     */
+    @Operation(summary = "List holds for a holder",
+            description = "Returns holds matching the given holder and status.")
+    @ApiResponse(responseCode = "200", description = "List of holds")
+    @GetMapping("/api/holds")
+    public List<SeatHoldResponse> listHolds(
+            @Parameter(description = "Holder identifier") @RequestParam String holderId,
+            @Parameter(description = "Filter by status") @RequestParam(defaultValue = "ACTIVE") HoldStatus status) {
+        return seatHoldService.listHolds(holderId, status)
+                .stream()
+                .map(SeatHoldResponse::from)
+                .toList();
+    }
 
-  /**
-   * Returns hold details visible only to the original holder.
-   *
-   * GET /api/holds/{holdId}?holderId=...
-   *
-   * @return 200 OK with the hold, or 404 if not found for this holder
-   */
-  @PermitAll
-  @GetMapping("/api/holds/{holdId}")
-  public SeatHoldResponse getHold(
-      @PathVariable UUID holdId,
-      @RequestParam String holderId) {
-    return SeatHoldResponse.from(seatHoldService.getHold(holdId, holderId));
-  }
+    /**
+     * Returns hold details visible only to the original holder.
+     *
+     * GET /api/holds/{holdId}?holderId=...
+     *
+     * @param holdId   the hold's unique ID
+     * @param holderId the holder's identifier (ownership check)
+     * @return 200 OK with the hold, or 404 if not found for this holder
+     */
+    @Operation(summary = "Get a hold by ID",
+            description = "Returns a single hold, scoped to the given holder.")
+    @ApiResponse(responseCode = "200", description = "Hold found")
+    @ApiResponse(responseCode = "404", description = "Hold not found for this holder")
+    @PermitAll
+    @GetMapping("/api/holds/{holdId}")
+    public SeatHoldResponse getHold(
+            @PathVariable UUID holdId,
+            @Parameter(description = "Holder identifier") @RequestParam String holderId) {
+        return SeatHoldResponse.from(seatHoldService.getHold(holdId, holderId));
+    }
 
-  /**
-   * Releases an active hold, freeing the seat for others.
-   * Idempotent: calling release on an already-RELEASED hold returns 200.
-   *
-   * POST /api/holds/{holdId}/release?holderId=...
-   *
-   * @return 200 OK with the updated hold
-   */
-  @PreAuthorize("isAuthenticated()")
-  @PostMapping("/api/holds/{holdId}/release")
-  public SeatHoldResponse releaseHold(
-      @PathVariable UUID holdId,
-      @RequestParam String holderId) {
-    return SeatHoldResponse.from(seatHoldService.releaseHold(holdId, holderId));
-  }
+    /**
+     * Releases an active hold, freeing the seat for others.
+     * Idempotent: calling release on an already-RELEASED hold returns 200.
+     *
+     * POST /api/holds/{holdId}/release?holderId=...
+     *
+     * @param holdId   the hold to release
+     * @param holderId the holder's identifier (ownership check)
+     * @return 200 OK with the updated hold
+     */
+    @Operation(summary = "Release a hold",
+            description = "Authenticated. Idempotent — frees the seat back to AVAILABLE.")
+    @ApiResponse(responseCode = "200", description = "Hold released")
+    @ApiResponse(responseCode = "404", description = "Hold not found")
+    @ApiResponse(responseCode = "409", description = "Hold already confirmed")
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/api/holds/{holdId}/release")
+    public SeatHoldResponse releaseHold(
+            @PathVariable UUID holdId,
+            @Parameter(description = "Holder identifier") @RequestParam String holderId) {
+        return SeatHoldResponse.from(seatHoldService.releaseHold(holdId, holderId));
+    }
 
-  /**
-   * Confirms an active hold, transitioning the seat to BOOKED.
-   * Idempotent: calling confirm on an already-CONFIRMED hold returns 200.
-   *
-   * POST /api/holds/{holdId}/confirm?holderId=...
-   *
-   * @return 200 OK with the updated hold
-   */
-  @PreAuthorize("isAuthenticated()")
-  @PostMapping("/api/holds/{holdId}/confirm")
-  public SeatHoldResponse confirmHold(
-      @PathVariable UUID holdId,
-      @RequestParam String holderId) {
-    return SeatHoldResponse.from(seatHoldService.confirmHold(holdId, holderId));
-  }
+    /**
+     * Confirms an active hold, transitioning the seat to BOOKED.
+     * Idempotent: calling confirm on an already-CONFIRMED hold returns 200.
+     *
+     * POST /api/holds/{holdId}/confirm?holderId=...
+     *
+     * @param holdId   the hold to confirm
+     * @param holderId the holder's identifier (ownership check)
+     * @return 200 OK with the updated hold
+     */
+    @Operation(summary = "Confirm a hold",
+            description = "Authenticated. Idempotent — transitions the seat to BOOKED.")
+    @ApiResponse(responseCode = "200", description = "Hold confirmed")
+    @ApiResponse(responseCode = "404", description = "Hold not found")
+    @ApiResponse(responseCode = "409", description = "Hold expired or already released")
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/api/holds/{holdId}/confirm")
+    public SeatHoldResponse confirmHold(
+            @PathVariable UUID holdId,
+            @Parameter(description = "Holder identifier") @RequestParam String holderId) {
+        return SeatHoldResponse.from(seatHoldService.confirmHold(holdId, holderId));
+    }
 }

--- a/backend/src/main/java/com/fairtix/inventory/domain/SeatStatus.java
+++ b/backend/src/main/java/com/fairtix/inventory/domain/SeatStatus.java
@@ -3,5 +3,6 @@ package com.fairtix.inventory.domain;
 public enum SeatStatus {
   AVAILABLE,
   HELD,
-  BOOKED
+  BOOKED,
+  SOLD
 }

--- a/backend/src/main/java/com/fairtix/inventory/dto/CreateHoldRequest.java
+++ b/backend/src/main/java/com/fairtix/inventory/dto/CreateHoldRequest.java
@@ -29,8 +29,8 @@ public record CreateHoldRequest(
         @Size(max = 10, message = "Cannot request more than 10 seats per hold")
         List<UUID> seatIds,
 
-        @Schema(description = "Opaque holder identifier (session or user ID)",
-                example = "user-session-abc123")
+        @Schema(description = "User ID of the holder (must match authenticated user for order creation)",
+                example = "d290f1ee-6c54-4b01-90e6-d701748f0851")
         @NotBlank(message = "holderId must not be blank")
         String holderId,
 

--- a/backend/src/main/java/com/fairtix/inventory/dto/CreateHoldRequest.java
+++ b/backend/src/main/java/com/fairtix/inventory/dto/CreateHoldRequest.java
@@ -1,5 +1,6 @@
 package com.fairtix.inventory.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -15,19 +16,26 @@ import java.util.UUID;
  * The service also enforces {@code holds.max-seats-per-hold} and
  * {@code holds.max-duration-minutes} so the limits hold even for direct calls.
  *
- * @param seatIds         the seats to hold (1–10 items)
+ * @param seatIds         the seats to hold (1-10 items)
  * @param holderId        opaque identifier for the holder (session/user id)
  * @param durationMinutes how long the hold lasts; server default when null
  */
+@Schema(description = "Payload for creating a temporary seat hold")
 public record CreateHoldRequest(
 
-    @NotEmpty(message = "At least one seat is required")
-    @Size(max = 10, message = "Cannot request more than 10 seats per hold")
-    List<UUID> seatIds,
+        @Schema(description = "Seat IDs to hold (1-10)",
+                example = "[\"a1b2c3d4-e5f6-7890-abcd-ef1234567890\"]")
+        @NotEmpty(message = "At least one seat is required")
+        @Size(max = 10, message = "Cannot request more than 10 seats per hold")
+        List<UUID> seatIds,
 
-    @NotBlank(message = "holderId must not be blank")
-    String holderId,
+        @Schema(description = "Opaque holder identifier (session or user ID)",
+                example = "user-session-abc123")
+        @NotBlank(message = "holderId must not be blank")
+        String holderId,
 
-    @Min(value = 1, message = "durationMinutes must be at least 1")
-    Integer durationMinutes) {
+        @Schema(description = "Hold duration in minutes (server default if omitted, max 60)",
+                example = "10")
+        @Min(value = 1, message = "durationMinutes must be at least 1")
+        Integer durationMinutes) {
 }

--- a/backend/src/main/java/com/fairtix/inventory/dto/CreateSeatRequest.java
+++ b/backend/src/main/java/com/fairtix/inventory/dto/CreateSeatRequest.java
@@ -1,5 +1,7 @@
 package com.fairtix.inventory.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * Request payload for creating a seat.
  *
@@ -7,8 +9,12 @@ package com.fairtix.inventory.dto;
  * @param rowLabel   the row within the section (e.g. "A", "B")
  * @param seatNumber the seat identifier within the row (e.g. "101")
  */
+@Schema(description = "Payload for creating a seat in an event's inventory")
 public record CreateSeatRequest(
-    String section,
-    String rowLabel,
-    String seatNumber) {
+        @Schema(description = "Seating section label", example = "Floor")
+        String section,
+        @Schema(description = "Row within the section", example = "A")
+        String rowLabel,
+        @Schema(description = "Seat identifier within the row", example = "101")
+        String seatNumber) {
 }

--- a/backend/src/main/java/com/fairtix/inventory/dto/SeatHoldResponse.java
+++ b/backend/src/main/java/com/fairtix/inventory/dto/SeatHoldResponse.java
@@ -27,7 +27,7 @@ public record SeatHoldResponse(
         UUID seatId,
         @Schema(description = "Event ID", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
         UUID eventId,
-        @Schema(description = "Holder identifier", example = "user-session-abc123")
+        @Schema(description = "Holder identifier (user ID)", example = "d290f1ee-6c54-4b01-90e6-d701748f0851")
         String holderId,
         @Schema(description = "Hold expiry time in UTC", example = "2026-07-15T19:10:00Z")
         Instant expiresAt,

--- a/backend/src/main/java/com/fairtix/inventory/dto/SeatHoldResponse.java
+++ b/backend/src/main/java/com/fairtix/inventory/dto/SeatHoldResponse.java
@@ -3,6 +3,8 @@ package com.fairtix.inventory.dto;
 import com.fairtix.inventory.domain.HoldStatus;
 import com.fairtix.inventory.domain.SeatHold;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.Instant;
 import java.util.UUID;
 
@@ -17,29 +19,37 @@ import java.util.UUID;
  * @param createdAt when the hold was created (UTC)
  * @param status    the current hold status
  */
+@Schema(description = "Seat hold details")
 public record SeatHoldResponse(
-    UUID id,
-    UUID seatId,
-    UUID eventId,
-    String holderId,
-    Instant expiresAt,
-    Instant createdAt,
-    HoldStatus status) {
+        @Schema(description = "Hold ID", example = "c3d4e5f6-a7b8-9012-cdef-123456789012")
+        UUID id,
+        @Schema(description = "Held seat ID", example = "b2c3d4e5-f6a7-8901-bcde-f12345678901")
+        UUID seatId,
+        @Schema(description = "Event ID", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+        UUID eventId,
+        @Schema(description = "Holder identifier", example = "user-session-abc123")
+        String holderId,
+        @Schema(description = "Hold expiry time in UTC", example = "2026-07-15T19:10:00Z")
+        Instant expiresAt,
+        @Schema(description = "Hold creation time in UTC", example = "2026-07-15T19:00:00Z")
+        Instant createdAt,
+        @Schema(description = "Hold status", example = "ACTIVE")
+        HoldStatus status) {
 
-  /**
-   * Maps a {@link SeatHold} entity to a {@link SeatHoldResponse}.
-   *
-   * @param hold the hold entity
-   * @return the corresponding response
-   */
-  public static SeatHoldResponse from(SeatHold hold) {
-    return new SeatHoldResponse(
-        hold.getId(),
-        hold.getSeat().getId(),
-        hold.getSeat().getEvent().getId(),
-        hold.getHolderId(),
-        hold.getExpiresAt(),
-        hold.getCreatedAt(),
-        hold.getStatus());
-  }
+    /**
+     * Maps a {@link SeatHold} entity to a {@link SeatHoldResponse}.
+     *
+     * @param hold the hold entity
+     * @return the corresponding response
+     */
+    public static SeatHoldResponse from(SeatHold hold) {
+        return new SeatHoldResponse(
+                hold.getId(),
+                hold.getSeat().getId(),
+                hold.getSeat().getEvent().getId(),
+                hold.getHolderId(),
+                hold.getExpiresAt(),
+                hold.getCreatedAt(),
+                hold.getStatus());
+    }
 }

--- a/backend/src/main/java/com/fairtix/inventory/dto/SeatResponse.java
+++ b/backend/src/main/java/com/fairtix/inventory/dto/SeatResponse.java
@@ -3,6 +3,8 @@ package com.fairtix.inventory.dto;
 import com.fairtix.inventory.domain.Seat;
 import com.fairtix.inventory.domain.SeatStatus;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.UUID;
 
 /**
@@ -15,27 +17,34 @@ import java.util.UUID;
  * @param seatNumber the individual seat number
  * @param status     the current availability status
  */
+@Schema(description = "Seat details")
 public record SeatResponse(
-    UUID id,
-    UUID eventId,
-    String section,
-    String rowLabel,
-    String seatNumber,
-    SeatStatus status) {
+        @Schema(description = "Seat ID", example = "b2c3d4e5-f6a7-8901-bcde-f12345678901")
+        UUID id,
+        @Schema(description = "Event ID", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+        UUID eventId,
+        @Schema(description = "Seating section", example = "Floor")
+        String section,
+        @Schema(description = "Row label", example = "A")
+        String rowLabel,
+        @Schema(description = "Seat number", example = "101")
+        String seatNumber,
+        @Schema(description = "Availability status", example = "AVAILABLE")
+        SeatStatus status) {
 
-  /**
-   * Maps a {@link Seat} entity to a {@link SeatResponse}.
-   *
-   * @param seat the seat entity
-   * @return the corresponding response
-   */
-  public static SeatResponse from(Seat seat) {
-    return new SeatResponse(
-        seat.getId(),
-        seat.getEvent().getId(),
-        seat.getSection(),
-        seat.getRowLabel(),
-        seat.getSeatNumber(),
-        seat.getStatus());
-  }
+    /**
+     * Maps a {@link Seat} entity to a {@link SeatResponse}.
+     *
+     * @param seat the seat entity
+     * @return the corresponding response
+     */
+    public static SeatResponse from(Seat seat) {
+        return new SeatResponse(
+                seat.getId(),
+                seat.getEvent().getId(),
+                seat.getSection(),
+                seat.getRowLabel(),
+                seat.getSeatNumber(),
+                seat.getStatus());
+    }
 }

--- a/backend/src/main/java/com/fairtix/inventory/infrastructure/SeatHoldRepository.java
+++ b/backend/src/main/java/com/fairtix/inventory/infrastructure/SeatHoldRepository.java
@@ -5,6 +5,8 @@ import com.fairtix.inventory.domain.SeatHold;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.Instant;
 import java.util.List;
@@ -12,6 +14,12 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface SeatHoldRepository extends JpaRepository<SeatHold, UUID> {
+
+  @Query("SELECT sh.status, COUNT(sh) FROM SeatHold sh GROUP BY sh.status")
+  List<Object[]> countByStatusGrouped();
+
+  @Query(value = "SELECT DATE(sh.created_at) AS day, COUNT(*) FROM seat_holds sh WHERE sh.created_at >= :since GROUP BY DATE(sh.created_at) ORDER BY day", nativeQuery = true)
+  List<Object[]> countHoldsPerDay(@Param("since") Instant since);
 
   Optional<SeatHold> findByIdAndHolderId(UUID id, String holderId);
 

--- a/backend/src/main/java/com/fairtix/inventory/infrastructure/SeatHoldRepository.java
+++ b/backend/src/main/java/com/fairtix/inventory/infrastructure/SeatHoldRepository.java
@@ -18,7 +18,7 @@ public interface SeatHoldRepository extends JpaRepository<SeatHold, UUID> {
   @Query("SELECT sh.status, COUNT(sh) FROM SeatHold sh GROUP BY sh.status")
   List<Object[]> countByStatusGrouped();
 
-  @Query(value = "SELECT DATE(sh.created_at) AS day, COUNT(*) FROM seat_holds sh WHERE sh.created_at >= :since GROUP BY DATE(sh.created_at) ORDER BY day", nativeQuery = true)
+  @Query(value = "SELECT CAST(sh.created_at AS DATE) AS hold_date, COUNT(*) FROM seat_holds sh WHERE sh.created_at >= :since GROUP BY CAST(sh.created_at AS DATE) ORDER BY hold_date", nativeQuery = true)
   List<Object[]> countHoldsPerDay(@Param("since") Instant since);
 
   Optional<SeatHold> findByIdAndHolderId(UUID id, String holderId);

--- a/backend/src/main/java/com/fairtix/inventory/infrastructure/SeatRepository.java
+++ b/backend/src/main/java/com/fairtix/inventory/infrastructure/SeatRepository.java
@@ -14,6 +14,12 @@ import java.util.UUID;
 
 public interface SeatRepository extends JpaRepository<Seat, UUID> {
 
+  @Query("SELECT s.status, COUNT(s) FROM Seat s GROUP BY s.status")
+  List<Object[]> countByStatusGrouped();
+
+  @Query("SELECT s.event.id, s.event.title, s.status, COUNT(s) FROM Seat s GROUP BY s.event.id, s.event.title, s.status")
+  List<Object[]> countByEventAndStatus();
+
   List<Seat> findByEvent_Id(UUID eventId);
 
   List<Seat> findByEvent_IdAndStatus(UUID eventId, SeatStatus status);

--- a/backend/src/main/java/com/fairtix/orders/api/OrderController.java
+++ b/backend/src/main/java/com/fairtix/orders/api/OrderController.java
@@ -1,0 +1,74 @@
+package com.fairtix.orders.api;
+
+import com.fairtix.orders.application.OrderService;
+import com.fairtix.orders.dto.CreateOrderRequest;
+import com.fairtix.orders.dto.OrderResponse;
+import com.fairtix.users.domain.User;
+import com.fairtix.users.infrastructure.UserRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@Tag(name = "Orders", description = "Order creation and retrieval")
+@RestController
+@PreAuthorize("isAuthenticated()")
+public class OrderController {
+
+    private final OrderService orderService;
+    private final UserRepository userRepository;
+
+    public OrderController(OrderService orderService, UserRepository userRepository) {
+        this.orderService = orderService;
+        this.userRepository = userRepository;
+    }
+
+    @Operation(summary = "Create an order from confirmed holds")
+    @ApiResponse(responseCode = "201", description = "Order created with tickets issued")
+    @ApiResponse(responseCode = "400", description = "Invalid holds")
+    @PostMapping("/api/orders")
+    @ResponseStatus(HttpStatus.CREATED)
+    public OrderResponse createOrder(
+            @AuthenticationPrincipal UserDetails principal,
+            @Valid @RequestBody CreateOrderRequest request) {
+        UUID userId = resolveUserId(principal);
+        return OrderResponse.from(orderService.createOrder(userId, request.holdIds()));
+    }
+
+    @Operation(summary = "List the current user's orders")
+    @ApiResponse(responseCode = "200", description = "List of orders")
+    @GetMapping("/api/orders")
+    public List<OrderResponse> listOrders(@AuthenticationPrincipal UserDetails principal) {
+        UUID userId = resolveUserId(principal);
+        return orderService.listOrders(userId).stream()
+                .map(OrderResponse::from)
+                .toList();
+    }
+
+    @Operation(summary = "Get order details")
+    @ApiResponse(responseCode = "200", description = "Order found")
+    @ApiResponse(responseCode = "404", description = "Order not found")
+    @GetMapping("/api/orders/{orderId}")
+    public OrderResponse getOrder(
+            @AuthenticationPrincipal UserDetails principal,
+            @PathVariable UUID orderId) {
+        UUID userId = resolveUserId(principal);
+        return OrderResponse.from(orderService.getOrder(orderId, userId));
+    }
+
+    private UUID resolveUserId(UserDetails principal) {
+        User user = userRepository.findByEmail(principal.getUsername())
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        return user.getId();
+    }
+}

--- a/backend/src/main/java/com/fairtix/orders/api/OrderController.java
+++ b/backend/src/main/java/com/fairtix/orders/api/OrderController.java
@@ -13,6 +13,7 @@ import jakarta.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
@@ -68,7 +69,8 @@ public class OrderController {
 
     private UUID resolveUserId(UserDetails principal) {
         User user = userRepository.findByEmail(principal.getUsername())
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.UNAUTHORIZED, "Authenticated user not found"));
         return user.getId();
     }
 }

--- a/backend/src/main/java/com/fairtix/orders/application/OrderNotFoundException.java
+++ b/backend/src/main/java/com/fairtix/orders/application/OrderNotFoundException.java
@@ -1,0 +1,8 @@
+package com.fairtix.orders.application;
+
+public class OrderNotFoundException extends RuntimeException {
+
+  public OrderNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/backend/src/main/java/com/fairtix/orders/application/OrderService.java
+++ b/backend/src/main/java/com/fairtix/orders/application/OrderService.java
@@ -1,6 +1,8 @@
 package com.fairtix.orders.application;
 
+import com.fairtix.inventory.application.SeatHoldConflictException;
 import com.fairtix.inventory.domain.HoldStatus;
+import com.fairtix.inventory.domain.Seat;
 import com.fairtix.inventory.domain.SeatHold;
 import com.fairtix.inventory.domain.SeatStatus;
 import com.fairtix.inventory.infrastructure.SeatHoldRepository;
@@ -57,10 +59,19 @@ public class OrderService {
       }
     }
 
-    // Transition seats from BOOKED → SOLD
+    // Transition seats from BOOKED → SOLD (guard against double-issue)
     for (SeatHold hold : holds) {
-      hold.getSeat().setStatus(SeatStatus.SOLD);
-      seatRepository.save(hold.getSeat());
+      Seat seat = hold.getSeat();
+      if (seat.getStatus() == SeatStatus.SOLD) {
+        throw new SeatHoldConflictException(
+            "Seat " + seat.getId() + " has already been sold");
+      }
+      if (seat.getStatus() != SeatStatus.BOOKED) {
+        throw new SeatHoldConflictException(
+            "Seat " + seat.getId() + " is not in BOOKED state (status: " + seat.getStatus() + ")");
+      }
+      seat.setStatus(SeatStatus.SOLD);
+      seatRepository.save(seat);
     }
 
     // Create the order (MVP: totalAmount = 0, no payment integration)

--- a/backend/src/main/java/com/fairtix/orders/application/OrderService.java
+++ b/backend/src/main/java/com/fairtix/orders/application/OrderService.java
@@ -1,0 +1,88 @@
+package com.fairtix.orders.application;
+
+import com.fairtix.inventory.domain.HoldStatus;
+import com.fairtix.inventory.domain.SeatHold;
+import com.fairtix.inventory.domain.SeatStatus;
+import com.fairtix.inventory.infrastructure.SeatHoldRepository;
+import com.fairtix.inventory.infrastructure.SeatRepository;
+import com.fairtix.orders.domain.Order;
+import com.fairtix.orders.infrastructure.OrderRepository;
+import com.fairtix.tickets.application.TicketService;
+import com.fairtix.users.domain.User;
+import com.fairtix.users.infrastructure.UserRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class OrderService {
+
+  private final OrderRepository orderRepository;
+  private final SeatHoldRepository seatHoldRepository;
+  private final SeatRepository seatRepository;
+  private final UserRepository userRepository;
+  private final TicketService ticketService;
+
+  public OrderService(OrderRepository orderRepository,
+      SeatHoldRepository seatHoldRepository,
+      SeatRepository seatRepository,
+      UserRepository userRepository,
+      TicketService ticketService) {
+    this.orderRepository = orderRepository;
+    this.seatHoldRepository = seatHoldRepository;
+    this.seatRepository = seatRepository;
+    this.userRepository = userRepository;
+    this.ticketService = ticketService;
+  }
+
+  @Transactional
+  public Order createOrder(UUID userId, List<UUID> holdIds) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+
+    // Validate all holds exist, belong to this user, and are CONFIRMED
+    List<SeatHold> holds = holdIds.stream()
+        .map(holdId -> seatHoldRepository.findByIdAndHolderId(holdId, userId.toString())
+            .orElseThrow(() -> new IllegalArgumentException(
+                "Hold not found or does not belong to you: " + holdId)))
+        .toList();
+
+    for (SeatHold hold : holds) {
+      if (hold.getStatus() != HoldStatus.CONFIRMED) {
+        throw new IllegalArgumentException(
+            "Hold " + hold.getId() + " is not confirmed (status: " + hold.getStatus() + ")");
+      }
+    }
+
+    // Transition seats from BOOKED → SOLD
+    for (SeatHold hold : holds) {
+      hold.getSeat().setStatus(SeatStatus.SOLD);
+      seatRepository.save(hold.getSeat());
+    }
+
+    // Create the order (MVP: totalAmount = 0, no payment integration)
+    Order order = new Order(user, holdIds, BigDecimal.ZERO, "USD");
+    order = orderRepository.save(order);
+
+    // Issue tickets for each hold
+    ticketService.issueTickets(order, holds);
+
+    return order;
+  }
+
+  public Order getOrder(UUID orderId, UUID userId) {
+    Order order = orderRepository.findById(orderId)
+        .orElseThrow(() -> new OrderNotFoundException("Order not found: " + orderId));
+    if (!order.getUser().getId().equals(userId)) {
+      throw new OrderNotFoundException("Order not found: " + orderId);
+    }
+    return order;
+  }
+
+  public List<Order> listOrders(UUID userId) {
+    return orderRepository.findAllByUser_IdOrderByCreatedAtDesc(userId);
+  }
+}

--- a/backend/src/main/java/com/fairtix/orders/domain/Order.java
+++ b/backend/src/main/java/com/fairtix/orders/domain/Order.java
@@ -1,0 +1,97 @@
+package com.fairtix.orders.domain;
+
+import com.fairtix.users.domain.User;
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "orders", indexes = {
+    @Index(name = "idx_order_user_id", columnList = "user_id"),
+    @Index(name = "idx_order_status", columnList = "status")
+})
+public class Order {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private UUID id;
+
+  @ManyToOne(fetch = FetchType.EAGER, optional = false)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private OrderStatus status;
+
+  @Column(nullable = false, precision = 10, scale = 2, name = "total_amount")
+  private BigDecimal totalAmount;
+
+  @Column(nullable = false, length = 3)
+  private String currency;
+
+  @ElementCollection
+  @CollectionTable(name = "order_holds", joinColumns = @JoinColumn(name = "order_id"))
+  @Column(name = "hold_id")
+  private List<UUID> holdIds = new ArrayList<>();
+
+  @Column(nullable = false, name = "created_at", updatable = false)
+  private Instant createdAt;
+
+  @Column(name = "updated_at")
+  private Instant updatedAt;
+
+  public Order(User user, List<UUID> holdIds, BigDecimal totalAmount, String currency) {
+    this.user = user;
+    this.holdIds = new ArrayList<>(holdIds);
+    this.totalAmount = totalAmount;
+    this.currency = currency;
+    this.status = OrderStatus.COMPLETED;
+    this.createdAt = Instant.now();
+    this.updatedAt = this.createdAt;
+  }
+
+  protected Order() {
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public User getUser() {
+    return user;
+  }
+
+  public OrderStatus getStatus() {
+    return status;
+  }
+
+  public BigDecimal getTotalAmount() {
+    return totalAmount;
+  }
+
+  public String getCurrency() {
+    return currency;
+  }
+
+  public List<UUID> getHoldIds() {
+    return holdIds;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public void setStatus(OrderStatus status) {
+    this.status = status;
+    this.updatedAt = Instant.now();
+  }
+}

--- a/backend/src/main/java/com/fairtix/orders/domain/OrderStatus.java
+++ b/backend/src/main/java/com/fairtix/orders/domain/OrderStatus.java
@@ -1,0 +1,8 @@
+package com.fairtix.orders.domain;
+
+public enum OrderStatus {
+  PENDING,
+  COMPLETED,
+  CANCELLED,
+  REFUNDED
+}

--- a/backend/src/main/java/com/fairtix/orders/dto/CreateOrderRequest.java
+++ b/backend/src/main/java/com/fairtix/orders/dto/CreateOrderRequest.java
@@ -1,0 +1,16 @@
+package com.fairtix.orders.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+import java.util.UUID;
+
+@Schema(description = "Payload for creating an order from confirmed holds")
+public record CreateOrderRequest(
+
+        @Schema(description = "IDs of confirmed holds to include in this order",
+                example = "[\"c3d4e5f6-a7b8-9012-cdef-123456789012\"]")
+        @NotEmpty(message = "At least one hold ID is required")
+        List<UUID> holdIds) {
+}

--- a/backend/src/main/java/com/fairtix/orders/dto/OrderResponse.java
+++ b/backend/src/main/java/com/fairtix/orders/dto/OrderResponse.java
@@ -1,0 +1,32 @@
+package com.fairtix.orders.dto;
+
+import com.fairtix.orders.domain.Order;
+import com.fairtix.orders.domain.OrderStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Schema(description = "Order details")
+public record OrderResponse(
+        @Schema(description = "Order ID") UUID id,
+        @Schema(description = "User ID") UUID userId,
+        @Schema(description = "Hold IDs included in this order") List<UUID> holdIds,
+        @Schema(description = "Order status") OrderStatus status,
+        @Schema(description = "Total amount") BigDecimal totalAmount,
+        @Schema(description = "Currency code") String currency,
+        @Schema(description = "When the order was created") Instant createdAt) {
+
+    public static OrderResponse from(Order order) {
+        return new OrderResponse(
+                order.getId(),
+                order.getUser().getId(),
+                order.getHoldIds(),
+                order.getStatus(),
+                order.getTotalAmount(),
+                order.getCurrency(),
+                order.getCreatedAt());
+    }
+}

--- a/backend/src/main/java/com/fairtix/orders/infrastructure/OrderRepository.java
+++ b/backend/src/main/java/com/fairtix/orders/infrastructure/OrderRepository.java
@@ -1,0 +1,12 @@
+package com.fairtix.orders.infrastructure;
+
+import com.fairtix.orders.domain.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface OrderRepository extends JpaRepository<Order, UUID> {
+
+  List<Order> findAllByUser_IdOrderByCreatedAtDesc(UUID userId);
+}

--- a/backend/src/main/java/com/fairtix/tickets/api/TicketController.java
+++ b/backend/src/main/java/com/fairtix/tickets/api/TicketController.java
@@ -1,0 +1,59 @@
+package com.fairtix.tickets.api;
+
+import com.fairtix.tickets.application.TicketService;
+import com.fairtix.tickets.dto.TicketResponse;
+import com.fairtix.users.domain.User;
+import com.fairtix.users.infrastructure.UserRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@Tag(name = "Tickets", description = "Ticket retrieval")
+@RestController
+@PreAuthorize("isAuthenticated()")
+public class TicketController {
+
+    private final TicketService ticketService;
+    private final UserRepository userRepository;
+
+    public TicketController(TicketService ticketService, UserRepository userRepository) {
+        this.ticketService = ticketService;
+        this.userRepository = userRepository;
+    }
+
+    @Operation(summary = "List the current user's tickets")
+    @ApiResponse(responseCode = "200", description = "List of tickets")
+    @GetMapping("/api/tickets")
+    public List<TicketResponse> listTickets(@AuthenticationPrincipal UserDetails principal) {
+        UUID userId = resolveUserId(principal);
+        return ticketService.listTickets(userId).stream()
+                .map(TicketResponse::from)
+                .toList();
+    }
+
+    @Operation(summary = "Get ticket details")
+    @ApiResponse(responseCode = "200", description = "Ticket found")
+    @ApiResponse(responseCode = "404", description = "Ticket not found")
+    @GetMapping("/api/tickets/{ticketId}")
+    public TicketResponse getTicket(
+            @AuthenticationPrincipal UserDetails principal,
+            @PathVariable UUID ticketId) {
+        UUID userId = resolveUserId(principal);
+        return TicketResponse.from(ticketService.getTicket(ticketId, userId));
+    }
+
+    private UUID resolveUserId(UserDetails principal) {
+        User user = userRepository.findByEmail(principal.getUsername())
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        return user.getId();
+    }
+}

--- a/backend/src/main/java/com/fairtix/tickets/api/TicketController.java
+++ b/backend/src/main/java/com/fairtix/tickets/api/TicketController.java
@@ -9,7 +9,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
@@ -53,7 +55,8 @@ public class TicketController {
 
     private UUID resolveUserId(UserDetails principal) {
         User user = userRepository.findByEmail(principal.getUsername())
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.UNAUTHORIZED, "Authenticated user not found"));
         return user.getId();
     }
 }

--- a/backend/src/main/java/com/fairtix/tickets/application/TicketService.java
+++ b/backend/src/main/java/com/fairtix/tickets/application/TicketService.java
@@ -1,0 +1,45 @@
+package com.fairtix.tickets.application;
+
+import com.fairtix.common.ResourceNotFoundException;
+import com.fairtix.inventory.domain.SeatHold;
+import com.fairtix.orders.domain.Order;
+import com.fairtix.tickets.domain.Ticket;
+import com.fairtix.tickets.infrastructure.TicketRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class TicketService {
+
+  private final TicketRepository ticketRepository;
+
+  public TicketService(TicketRepository ticketRepository) {
+    this.ticketRepository = ticketRepository;
+  }
+
+  public void issueTickets(Order order, List<SeatHold> holds) {
+    List<Ticket> tickets = holds.stream()
+        .map(hold -> new Ticket(
+            order,
+            order.getUser(),
+            hold.getSeat(),
+            hold.getSeat().getEvent()))
+        .toList();
+    ticketRepository.saveAll(tickets);
+  }
+
+  public List<Ticket> listTickets(UUID userId) {
+    return ticketRepository.findAllByUser_IdOrderByIssuedAtDesc(userId);
+  }
+
+  public Ticket getTicket(UUID ticketId, UUID userId) {
+    Ticket ticket = ticketRepository.findById(ticketId)
+        .orElseThrow(() -> new ResourceNotFoundException("Ticket not found: " + ticketId));
+    if (!ticket.getUser().getId().equals(userId)) {
+      throw new ResourceNotFoundException("Ticket not found: " + ticketId);
+    }
+    return ticket;
+  }
+}

--- a/backend/src/main/java/com/fairtix/tickets/domain/Ticket.java
+++ b/backend/src/main/java/com/fairtix/tickets/domain/Ticket.java
@@ -1,0 +1,90 @@
+package com.fairtix.tickets.domain;
+
+import com.fairtix.events.domain.Event;
+import com.fairtix.inventory.domain.Seat;
+import com.fairtix.orders.domain.Order;
+import com.fairtix.users.domain.User;
+import jakarta.persistence.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "tickets", indexes = {
+    @Index(name = "idx_ticket_user_id", columnList = "user_id"),
+    @Index(name = "idx_ticket_order_id", columnList = "order_id"),
+    @Index(name = "idx_ticket_event_id", columnList = "event_id")
+})
+public class Ticket {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private UUID id;
+
+  @ManyToOne(fetch = FetchType.EAGER, optional = false)
+  @JoinColumn(name = "order_id", nullable = false)
+  private Order order;
+
+  @ManyToOne(fetch = FetchType.EAGER, optional = false)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @ManyToOne(fetch = FetchType.EAGER, optional = false)
+  @JoinColumn(name = "seat_id", nullable = false)
+  private Seat seat;
+
+  @ManyToOne(fetch = FetchType.EAGER, optional = false)
+  @JoinColumn(name = "event_id", nullable = false)
+  private Event event;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private TicketStatus status;
+
+  @Column(name = "issued_at", nullable = false, updatable = false)
+  private Instant issuedAt;
+
+  public Ticket(Order order, User user, Seat seat, Event event) {
+    this.order = order;
+    this.user = user;
+    this.seat = seat;
+    this.event = event;
+    this.status = TicketStatus.VALID;
+    this.issuedAt = Instant.now();
+  }
+
+  protected Ticket() {
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public Order getOrder() {
+    return order;
+  }
+
+  public User getUser() {
+    return user;
+  }
+
+  public Seat getSeat() {
+    return seat;
+  }
+
+  public Event getEvent() {
+    return event;
+  }
+
+  public TicketStatus getStatus() {
+    return status;
+  }
+
+  public Instant getIssuedAt() {
+    return issuedAt;
+  }
+
+  public void setStatus(TicketStatus status) {
+    this.status = status;
+  }
+}

--- a/backend/src/main/java/com/fairtix/tickets/domain/TicketStatus.java
+++ b/backend/src/main/java/com/fairtix/tickets/domain/TicketStatus.java
@@ -1,0 +1,8 @@
+package com.fairtix.tickets.domain;
+
+public enum TicketStatus {
+  VALID,
+  USED,
+  TRANSFERRED,
+  CANCELLED
+}

--- a/backend/src/main/java/com/fairtix/tickets/dto/TicketResponse.java
+++ b/backend/src/main/java/com/fairtix/tickets/dto/TicketResponse.java
@@ -1,0 +1,42 @@
+package com.fairtix.tickets.dto;
+
+import com.fairtix.tickets.domain.Ticket;
+import com.fairtix.tickets.domain.TicketStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Schema(description = "Ticket details")
+public record TicketResponse(
+        @Schema(description = "Ticket ID") UUID id,
+        @Schema(description = "Order ID") UUID orderId,
+        @Schema(description = "Event ID") UUID eventId,
+        @Schema(description = "Event title") String eventTitle,
+        @Schema(description = "Event venue") String eventVenue,
+        @Schema(description = "Event start time") Instant eventStartTime,
+        @Schema(description = "Seat ID") UUID seatId,
+        @Schema(description = "Seat section") String seatSection,
+        @Schema(description = "Seat row") String seatRow,
+        @Schema(description = "Seat number") String seatNumber,
+        @Schema(description = "Ticket holder email") String holderEmail,
+        @Schema(description = "Ticket status") TicketStatus status,
+        @Schema(description = "When the ticket was issued") Instant issuedAt) {
+
+    public static TicketResponse from(Ticket ticket) {
+        return new TicketResponse(
+                ticket.getId(),
+                ticket.getOrder().getId(),
+                ticket.getEvent().getId(),
+                ticket.getEvent().getTitle(),
+                ticket.getEvent().getVenue(),
+                ticket.getEvent().getStartTime(),
+                ticket.getSeat().getId(),
+                ticket.getSeat().getSection(),
+                ticket.getSeat().getRowLabel(),
+                ticket.getSeat().getSeatNumber(),
+                ticket.getUser().getEmail(),
+                ticket.getStatus(),
+                ticket.getIssuedAt());
+    }
+}

--- a/backend/src/main/java/com/fairtix/tickets/infrastructure/TicketRepository.java
+++ b/backend/src/main/java/com/fairtix/tickets/infrastructure/TicketRepository.java
@@ -1,0 +1,14 @@
+package com.fairtix.tickets.infrastructure;
+
+import com.fairtix.tickets.domain.Ticket;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface TicketRepository extends JpaRepository<Ticket, UUID> {
+
+  List<Ticket> findAllByUser_IdOrderByIssuedAtDesc(UUID userId);
+
+  List<Ticket> findAllByOrder_Id(UUID orderId);
+}

--- a/backend/src/main/java/com/fairtix/users/api/AdminController.java
+++ b/backend/src/main/java/com/fairtix/users/api/AdminController.java
@@ -15,33 +15,61 @@ import com.fairtix.users.domain.User;
 import com.fairtix.users.domain.Role;
 import com.fairtix.users.dto.UserResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 import java.util.UUID;
 
+/**
+ * Admin-only user management endpoints.
+ *
+ * <p>Provides a paginated user list and the ability to promote users to admin.
+ */
+@Tag(name = "Admin", description = "User administration")
 @RestController
 @RequestMapping("/api/admin")
 @RequiredArgsConstructor
 public class AdminController {
 
-  private final UserRepository userRepository;
+    private final UserRepository userRepository;
 
-  @GetMapping("/users")
-  @PreAuthorize("hasRole('ADMIN')")
-  public Page<UserResponse> listUsers(
-      @RequestParam(defaultValue = "0") int page,
-      @RequestParam(defaultValue = "20") int size) {
-    return userRepository.findAll(PageRequest.of(page, Math.min(size, 100)))
-        .map(UserResponse::from);
-  }
+    /**
+     * Returns a paginated list of all users.
+     *
+     * @param page zero-based page index
+     * @param size number of users per page (max 100)
+     * @return a page of user records
+     */
+    @Operation(summary = "List all users", description = "Admin-only. Returns a paginated list of users.")
+    @ApiResponse(responseCode = "200", description = "Page of users")
+    @ApiResponse(responseCode = "403", description = "Not an admin")
+    @GetMapping("/users")
+    @PreAuthorize("hasRole('ADMIN')")
+    public Page<UserResponse> listUsers(
+            @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size (max 100)") @RequestParam(defaultValue = "20") int size) {
+        return userRepository.findAll(PageRequest.of(page, Math.min(size, 100)))
+                .map(UserResponse::from);
+    }
 
-  @PatchMapping("/users/{id}/promote")
-  @PreAuthorize("hasRole('ADMIN')")
-  public void promoteUser(@PathVariable UUID id) {
-    User user = userRepository.findById(id)
-        .orElseThrow(() -> new IllegalArgumentException("User not found: " + id));
+    /**
+     * Promotes a user to the ADMIN role.
+     *
+     * @param id the UUID of the user to promote
+     */
+    @Operation(summary = "Promote user to admin", description = "Admin-only. Sets the user's role to ADMIN.")
+    @ApiResponse(responseCode = "200", description = "User promoted")
+    @ApiResponse(responseCode = "400", description = "User not found")
+    @PatchMapping("/users/{id}/promote")
+    @PreAuthorize("hasRole('ADMIN')")
+    public void promoteUser(@PathVariable UUID id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + id));
 
-    user.setRole(Role.ADMIN);
-    userRepository.save(user);
-  }
+        user.setRole(Role.ADMIN);
+        userRepository.save(user);
+    }
 }

--- a/backend/src/main/java/com/fairtix/users/dto/AuthResponse.java
+++ b/backend/src/main/java/com/fairtix/users/dto/AuthResponse.java
@@ -1,0 +1,9 @@
+package com.fairtix.users.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Authentication response containing a JWT token")
+public record AuthResponse(
+        @Schema(description = "JWT bearer token", example = "eyJhbGciOiJIUzI1NiJ9...")
+        String token) {
+}

--- a/backend/src/main/java/com/fairtix/users/dto/LoginRequest.java
+++ b/backend/src/main/java/com/fairtix/users/dto/LoginRequest.java
@@ -1,6 +1,11 @@
 package com.fairtix.users.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Login credentials")
 public record LoginRequest(
-    String email,
-    String password) {
+        @Schema(description = "User email address", example = "user@example.com")
+        String email,
+        @Schema(description = "User password", example = "password123")
+        String password) {
 }

--- a/backend/src/main/java/com/fairtix/users/dto/RegisterRequest.java
+++ b/backend/src/main/java/com/fairtix/users/dto/RegisterRequest.java
@@ -1,6 +1,11 @@
 package com.fairtix.users.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "New user registration payload")
 public record RegisterRequest(
-    String email,
-    String password) {
+        @Schema(description = "Email address for the new account", example = "newuser@example.com")
+        String email,
+        @Schema(description = "Password (plaintext, will be hashed)", example = "password123")
+        String password) {
 }

--- a/backend/src/main/java/com/fairtix/users/dto/UserResponse.java
+++ b/backend/src/main/java/com/fairtix/users/dto/UserResponse.java
@@ -3,9 +3,18 @@ package com.fairtix.users.dto;
 import com.fairtix.users.domain.Role;
 import com.fairtix.users.domain.User;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.UUID;
 
-public record UserResponse(UUID id, String email, Role role) {
+@Schema(description = "User details")
+public record UserResponse(
+        @Schema(description = "User ID", example = "d290f1ee-6c54-4b01-90e6-d701748f0851")
+        UUID id,
+        @Schema(description = "Email address", example = "user@example.com")
+        String email,
+        @Schema(description = "User role", example = "USER")
+        Role role) {
 
     public static UserResponse from(User user) {
         return new UserResponse(user.getId(), user.getEmail(), user.getRole());

--- a/backend/src/main/java/com/fairtix/users/infrastructure/UserRepository.java
+++ b/backend/src/main/java/com/fairtix/users/infrastructure/UserRepository.java
@@ -1,9 +1,11 @@
 package com.fairtix.users.infrastructure;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.fairtix.users.domain.User;
@@ -11,4 +13,7 @@ import com.fairtix.users.domain.User;
 @Repository
 public interface UserRepository extends JpaRepository<User, UUID> {
   Optional<User> findByEmail(String email);
+
+  @Query("SELECT u.role, COUNT(u) FROM User u GROUP BY u.role")
+  List<Object[]> countByRoleGrouped();
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -26,3 +26,9 @@ holds.max-active-per-holder=5
 
 # Logging
 logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} [%X{requestId}] %-5level %logger - %msg%n
+
+# OpenAPI / Swagger
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.operations-sorter=method
+springdoc.swagger-ui.tags-sorter=alpha

--- a/backend/src/test/java/com/fairtix/analytics/api/AnalyticsControllerTest.java
+++ b/backend/src/test/java/com/fairtix/analytics/api/AnalyticsControllerTest.java
@@ -61,6 +61,7 @@ class AnalyticsControllerTest {
         .andExpect(jsonPath("$.seatsByStatus").value(hasKey("AVAILABLE")))
         .andExpect(jsonPath("$.seatsByStatus").value(hasKey("HELD")))
         .andExpect(jsonPath("$.seatsByStatus").value(hasKey("BOOKED")))
+        .andExpect(jsonPath("$.seatsByStatus").value(hasKey("SOLD")))
         .andExpect(jsonPath("$.holdsByStatus").value(hasKey("ACTIVE")))
         .andExpect(jsonPath("$.holdConfirmationRate").value(0.0))
         .andExpect(jsonPath("$.holdsPerDay").isArray())
@@ -92,6 +93,7 @@ class AnalyticsControllerTest {
         .andExpect(jsonPath("$.overview.totalSeats").value(0))
         .andExpect(jsonPath("$.overview.bookedSeats").value(0))
         .andExpect(jsonPath("$.overview.activeHolds").value(0))
+        .andExpect(jsonPath("$.overview.soldSeats").value(0))
         .andExpect(jsonPath("$.holdConfirmationRate").value(0.0));
   }
 }

--- a/backend/src/test/java/com/fairtix/analytics/api/AnalyticsControllerTest.java
+++ b/backend/src/test/java/com/fairtix/analytics/api/AnalyticsControllerTest.java
@@ -1,0 +1,97 @@
+package com.fairtix.analytics.api;
+
+import com.fairtix.events.application.EventService;
+import com.fairtix.inventory.application.SeatService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.Instant;
+
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Transactional
+class AnalyticsControllerTest {
+
+  @Autowired
+  private WebApplicationContext context;
+
+  @Autowired
+  private EventService eventService;
+
+  @Autowired
+  private SeatService seatService;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context)
+        .apply(springSecurity())
+        .build();
+  }
+
+  @Test
+  void getDashboard_asAdmin_returns200WithExpectedShape() throws Exception {
+    // Seed some data so the response has non-empty fields
+    var event = eventService.createEvent("Test Show", Instant.parse("2026-08-01T20:00:00Z"), "Arena A");
+    seatService.createSeat(event.getId(), "VIP", "A", "1");
+    seatService.createSeat(event.getId(), "VIP", "A", "2");
+
+    mockMvc.perform(get("/api/analytics/dashboard")
+            .with(user("admin@test.com").roles("ADMIN"))
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.overview").value(notNullValue()))
+        .andExpect(jsonPath("$.overview.totalEvents").value(1))
+        .andExpect(jsonPath("$.overview.totalSeats").value(2))
+        .andExpect(jsonPath("$.overview.totalUsers").value(0))
+        .andExpect(jsonPath("$.seatsByStatus").value(hasKey("AVAILABLE")))
+        .andExpect(jsonPath("$.seatsByStatus").value(hasKey("HELD")))
+        .andExpect(jsonPath("$.seatsByStatus").value(hasKey("BOOKED")))
+        .andExpect(jsonPath("$.holdsByStatus").value(hasKey("ACTIVE")))
+        .andExpect(jsonPath("$.holdConfirmationRate").value(0.0))
+        .andExpect(jsonPath("$.holdsPerDay").isArray())
+        .andExpect(jsonPath("$.eventsByVenue").isArray())
+        .andExpect(jsonPath("$.topEventsByBookings").isArray())
+        .andExpect(jsonPath("$.usersByRole").exists());
+  }
+
+  @Test
+  void getDashboard_asUser_returns403() throws Exception {
+    mockMvc.perform(get("/api/analytics/dashboard")
+            .with(user("user@test.com").roles("USER")))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void getDashboard_unauthenticated_returns403() throws Exception {
+    mockMvc.perform(get("/api/analytics/dashboard"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void getDashboard_emptyDatabase_returns200WithZeros() throws Exception {
+    mockMvc.perform(get("/api/analytics/dashboard")
+            .with(user("admin@test.com").roles("ADMIN"))
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.overview.totalEvents").value(0))
+        .andExpect(jsonPath("$.overview.totalSeats").value(0))
+        .andExpect(jsonPath("$.overview.bookedSeats").value(0))
+        .andExpect(jsonPath("$.overview.activeHolds").value(0))
+        .andExpect(jsonPath("$.holdConfirmationRate").value(0.0));
+  }
+}

--- a/backend/src/test/java/com/fairtix/config/TestRedisConfig.java
+++ b/backend/src/test/java/com/fairtix/config/TestRedisConfig.java
@@ -1,0 +1,31 @@
+package com.fairtix.config;
+
+import org.mockito.Mockito;
+import org.redisson.api.RRateLimiter;
+import org.redisson.api.RedissonClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Replaces the real RedissonClient with a mock for tests,
+ * so tests don't need a running Redis instance.
+ */
+@Configuration
+public class TestRedisConfig {
+
+  @Bean
+  @Primary
+  public RedissonClient redissonClient() {
+    RedissonClient mock = Mockito.mock(RedissonClient.class);
+    RRateLimiter limiter = Mockito.mock(RRateLimiter.class);
+    when(mock.getRateLimiter(anyString())).thenReturn(limiter);
+    when(limiter.tryAcquire(1)).thenReturn(true);
+    when(limiter.isExists()).thenReturn(false);
+    when(limiter.trySetRate(Mockito.any(), Mockito.anyLong(), Mockito.anyLong(), Mockito.any())).thenReturn(true);
+    return mock;
+  }
+}

--- a/backend/src/test/java/com/fairtix/orders/api/OrderControllerTest.java
+++ b/backend/src/test/java/com/fairtix/orders/api/OrderControllerTest.java
@@ -1,0 +1,144 @@
+package com.fairtix.orders.api;
+
+import com.fairtix.events.domain.Event;
+import com.fairtix.events.infrastructure.EventRepository;
+import com.fairtix.inventory.domain.HoldStatus;
+import com.fairtix.inventory.domain.Seat;
+import com.fairtix.inventory.domain.SeatHold;
+import com.fairtix.inventory.domain.SeatStatus;
+import com.fairtix.inventory.infrastructure.SeatHoldRepository;
+import com.fairtix.inventory.infrastructure.SeatRepository;
+import com.fairtix.users.domain.User;
+import com.fairtix.users.infrastructure.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.Instant;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Transactional
+class OrderControllerTest {
+
+  @Autowired
+  private WebApplicationContext context;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private EventRepository eventRepository;
+
+  @Autowired
+  private SeatRepository seatRepository;
+
+  @Autowired
+  private SeatHoldRepository seatHoldRepository;
+
+  private MockMvc mockMvc;
+  private User testUser;
+
+  @BeforeEach
+  void setUp() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context)
+        .apply(springSecurity())
+        .build();
+
+    testUser = new User();
+    testUser.setEmail("ordertest@example.com");
+    testUser.setPassword("$2a$10$dummyhashfortest");
+    testUser = userRepository.save(testUser);
+  }
+
+  @Test
+  void createOrder_unauthenticated_returns403() throws Exception {
+    String body = """
+        { "holdIds": ["00000000-0000-0000-0000-000000000001"] }
+        """;
+
+    mockMvc.perform(post("/api/orders")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser(username = "ordertest@example.com")
+  void createOrder_emptyHoldIds_returns400() throws Exception {
+    String body = """
+        { "holdIds": [] }
+        """;
+
+    mockMvc.perform(post("/api/orders")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+  }
+
+  @Test
+  @WithMockUser(username = "ordertest@example.com")
+  void createOrder_nonExistentHold_returns400() throws Exception {
+    String body = """
+        { "holdIds": ["00000000-0000-0000-0000-000000000001"] }
+        """;
+
+    mockMvc.perform(post("/api/orders")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("BAD_REQUEST"));
+  }
+
+  @Test
+  @WithMockUser(username = "ordertest@example.com")
+  void createOrder_withConfirmedHold_returns201() throws Exception {
+    // Set up: event → seat → confirmed hold
+    Event event = eventRepository.save(new Event("Test Concert", "Test Venue", Instant.now().plusSeconds(86400)));
+    Seat seat = seatRepository.save(new Seat(event, "A", "1", "101"));
+    seat.setStatus(SeatStatus.BOOKED);
+    seat = seatRepository.save(seat);
+
+    SeatHold hold = new SeatHold(seat, testUser.getId().toString(), Instant.now().plusSeconds(600));
+    hold.setStatus(HoldStatus.CONFIRMED);
+    hold = seatHoldRepository.save(hold);
+
+    String body = """
+        { "holdIds": ["%s"] }
+        """.formatted(hold.getId());
+
+    mockMvc.perform(post("/api/orders")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id").exists())
+        .andExpect(jsonPath("$.userId").value(testUser.getId().toString()))
+        .andExpect(jsonPath("$.status").value("COMPLETED"));
+  }
+
+  @Test
+  @WithMockUser(username = "ordertest@example.com")
+  void listOrders_returnsEmptyWhenNone() throws Exception {
+    mockMvc.perform(get("/api/orders"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(0));
+  }
+
+  @Test
+  void listOrders_unauthenticated_returns403() throws Exception {
+    mockMvc.perform(get("/api/orders"))
+        .andExpect(status().isForbidden());
+  }
+}

--- a/backend/src/test/java/com/fairtix/tickets/api/TicketControllerTest.java
+++ b/backend/src/test/java/com/fairtix/tickets/api/TicketControllerTest.java
@@ -1,0 +1,143 @@
+package com.fairtix.tickets.api;
+
+import com.fairtix.events.domain.Event;
+import com.fairtix.events.infrastructure.EventRepository;
+import com.fairtix.inventory.domain.HoldStatus;
+import com.fairtix.inventory.domain.Seat;
+import com.fairtix.inventory.domain.SeatHold;
+import com.fairtix.inventory.domain.SeatStatus;
+import com.fairtix.inventory.infrastructure.SeatHoldRepository;
+import com.fairtix.inventory.infrastructure.SeatRepository;
+import com.fairtix.orders.application.OrderService;
+import com.fairtix.users.domain.User;
+import com.fairtix.users.infrastructure.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Transactional
+class TicketControllerTest {
+
+  @Autowired
+  private WebApplicationContext context;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private EventRepository eventRepository;
+
+  @Autowired
+  private SeatRepository seatRepository;
+
+  @Autowired
+  private SeatHoldRepository seatHoldRepository;
+
+  @Autowired
+  private OrderService orderService;
+
+  private MockMvc mockMvc;
+  private User testUser;
+
+  @BeforeEach
+  void setUp() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context)
+        .apply(springSecurity())
+        .build();
+
+    testUser = new User();
+    testUser.setEmail("tickettest@example.com");
+    testUser.setPassword("$2a$10$dummyhashfortest");
+    testUser = userRepository.save(testUser);
+  }
+
+  @Test
+  void listTickets_unauthenticated_returns403() throws Exception {
+    mockMvc.perform(get("/api/tickets"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser(username = "tickettest@example.com")
+  void listTickets_returnsEmptyWhenNone() throws Exception {
+    mockMvc.perform(get("/api/tickets"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(0));
+  }
+
+  @Test
+  @WithMockUser(username = "tickettest@example.com")
+  void listTickets_returnsTicketsAfterOrder() throws Exception {
+    // Set up: event → seat → confirmed hold → order → tickets
+    Event event = eventRepository.save(new Event("Ticket Concert", "Ticket Venue", Instant.now().plusSeconds(86400)));
+    Seat seat = seatRepository.save(new Seat(event, "B", "2", "205"));
+    seat.setStatus(SeatStatus.BOOKED);
+    seat = seatRepository.save(seat);
+
+    SeatHold hold = new SeatHold(seat, testUser.getId().toString(), Instant.now().plusSeconds(600));
+    hold.setStatus(HoldStatus.CONFIRMED);
+    hold = seatHoldRepository.save(hold);
+
+    // Create the order (which issues tickets)
+    orderService.createOrder(testUser.getId(), List.of(hold.getId()));
+
+    mockMvc.perform(get("/api/tickets"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(1))
+        .andExpect(jsonPath("$[0].eventTitle").value("Ticket Concert"))
+        .andExpect(jsonPath("$[0].seatSection").value("B"))
+        .andExpect(jsonPath("$[0].seatRow").value("2"))
+        .andExpect(jsonPath("$[0].seatNumber").value("205"))
+        .andExpect(jsonPath("$[0].status").value("VALID"));
+  }
+
+  @Test
+  @WithMockUser(username = "tickettest@example.com")
+  void getTicket_notFound_returns404() throws Exception {
+    mockMvc.perform(get("/api/tickets/{ticketId}", UUID.randomUUID()))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
+  }
+
+  @Test
+  @WithMockUser(username = "other@example.com")
+  void getTicket_belongingToOtherUser_returns404() throws Exception {
+    // Create another user to test ownership isolation
+    User otherUser = new User();
+    otherUser.setEmail("other@example.com");
+    otherUser.setPassword("$2a$10$dummyhashfortest");
+    otherUser = userRepository.save(otherUser);
+
+    // Create order/ticket for testUser
+    Event event = eventRepository.save(new Event("Private Show", "Venue", Instant.now().plusSeconds(86400)));
+    Seat seat = seatRepository.save(new Seat(event, "C", "1", "1"));
+    seat.setStatus(SeatStatus.BOOKED);
+    seat = seatRepository.save(seat);
+
+    SeatHold hold = new SeatHold(seat, testUser.getId().toString(), Instant.now().plusSeconds(600));
+    hold.setStatus(HoldStatus.CONFIRMED);
+    hold = seatHoldRepository.save(hold);
+
+    orderService.createOrder(testUser.getId(), List.of(hold.getId()));
+
+    // otherUser should see empty tickets, not testUser's
+    mockMvc.perform(get("/api/tickets"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(0));
+  }
+}

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -1,0 +1,254 @@
+# FairTix API Contract
+
+> **Version:** 1.0.0
+> **Base URL:** `http://localhost:8080`
+> **Interactive docs:** `http://localhost:8080/swagger-ui.html`
+> **OpenAPI spec:** `http://localhost:8080/v3/api-docs`
+
+## Authentication
+
+All protected endpoints require a JWT bearer token in the `Authorization` header:
+
+```
+Authorization: Bearer <token>
+```
+
+Tokens are obtained from the Auth endpoints and expire after 15 minutes.
+
+---
+
+## Implemented Endpoints
+
+### Auth
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/auth/register` | Public | Register a new user |
+| POST | `/auth/login` | Public | Log in and receive a JWT |
+
+**Request body (both):**
+```json
+{
+  "email": "user@example.com",
+  "password": "password123"
+}
+```
+
+**Response:**
+```json
+{
+  "token": "eyJhbGciOiJIUzI1NiJ9..."
+}
+```
+
+### Events
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/api/events` | ADMIN | Create an event |
+| GET | `/api/events` | Public | Search/list events (paginated) |
+| GET | `/api/events/{id}` | Public | Get a single event |
+| PUT | `/api/events/{id}` | ADMIN | Update an event |
+| DELETE | `/api/events/{id}` | ADMIN | Delete an event |
+
+**Create/Update request:**
+```json
+{
+  "title": "Summer Music Festival",
+  "startTime": "2026-07-15T19:00:00Z",
+  "venue": "Madison Square Garden"
+}
+```
+
+**Event response:**
+```json
+{
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "title": "Summer Music Festival",
+  "startTime": "2026-07-15T19:00:00Z",
+  "venue": "Madison Square Garden"
+}
+```
+
+**Search query parameters:** `venueName`, `title`, `upcoming` (boolean), `page` (default 0), `size` (default 20, max 100)
+
+### Seats
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/api/events/{eventId}/seats` | ADMIN | Create a seat |
+| GET | `/api/events/{eventId}/seats` | Public | List seats for an event |
+
+**Create request:**
+```json
+{
+  "section": "Floor",
+  "rowLabel": "A",
+  "seatNumber": "101"
+}
+```
+
+**Seat response:**
+```json
+{
+  "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  "eventId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "section": "Floor",
+  "rowLabel": "A",
+  "seatNumber": "101",
+  "status": "AVAILABLE"
+}
+```
+
+**List query parameters:** `availableOnly` (boolean, default false)
+
+### Holds
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/api/events/{eventId}/holds` | Authenticated | Create a hold on 1-10 seats |
+| GET | `/api/holds` | Authenticated | List holds for a holder |
+| GET | `/api/holds/{holdId}` | Public | Get a single hold |
+| POST | `/api/holds/{holdId}/release` | Authenticated | Release a hold (idempotent) |
+| POST | `/api/holds/{holdId}/confirm` | Authenticated | Confirm a hold (idempotent) |
+
+**Create hold request:**
+```json
+{
+  "seatIds": ["b2c3d4e5-f6a7-8901-bcde-f12345678901"],
+  "holderId": "user-session-abc123",
+  "durationMinutes": 10
+}
+```
+
+**Hold response:**
+```json
+{
+  "id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+  "seatId": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  "eventId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "holderId": "user-session-abc123",
+  "expiresAt": "2026-07-15T19:10:00Z",
+  "createdAt": "2026-07-15T19:00:00Z",
+  "status": "ACTIVE"
+}
+```
+
+**Hold statuses:** `ACTIVE`, `CONFIRMED`, `EXPIRED`, `RELEASED`
+
+**Constraints:**
+- Max 10 seats per hold request
+- Max 5 active holds per holder
+- Duration: 1-60 minutes (default 10)
+- Holds expire automatically after the specified duration
+
+### Analytics
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/api/analytics/dashboard` | ADMIN | Aggregate dashboard stats |
+
+**Response:** see Swagger UI for the full `AnalyticsResponse` schema.
+
+### Admin
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/api/admin/users` | ADMIN | List all users (paginated) |
+| PATCH | `/api/admin/users/{id}/promote` | ADMIN | Promote a user to admin |
+
+---
+
+## Error Response Format
+
+All errors follow a consistent shape:
+
+```json
+{
+  "status": 409,
+  "code": "HOLD_CONFLICT",
+  "message": "Seat b2c3d4e5-... is not available",
+  "path": "/api/holds/abc/confirm",
+  "timestamp": "2026-07-15T19:00:00Z"
+}
+```
+
+**Error codes:** `HOLD_NOT_FOUND`, `HOLD_CONFLICT`, `BAD_REQUEST`, `VALIDATION_ERROR`, `UNAUTHORIZED`, `FORBIDDEN`, `RESOURCE_NOT_FOUND`
+
+---
+
+## Planned Endpoints (Not Yet Implemented)
+
+### Orders
+
+Future endpoints for completing a purchase after confirming a hold.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/api/orders` | Authenticated | Create an order from confirmed holds |
+| GET | `/api/orders` | Authenticated | List the current user's orders |
+| GET | `/api/orders/{orderId}` | Authenticated | Get order details |
+| POST | `/api/orders/{orderId}/cancel` | Authenticated | Cancel an order (if refundable) |
+| GET | `/api/admin/orders` | ADMIN | List all orders (admin) |
+
+**Planned create order request:**
+```json
+{
+  "holdIds": ["c3d4e5f6-a7b8-9012-cdef-123456789012"],
+  "paymentMethod": "CARD"
+}
+```
+
+**Planned order response:**
+```json
+{
+  "id": "d4e5f6a7-b8c9-0123-defa-234567890123",
+  "userId": "d290f1ee-6c54-4b01-90e6-d701748f0851",
+  "holdIds": ["c3d4e5f6-a7b8-9012-cdef-123456789012"],
+  "status": "COMPLETED",
+  "totalAmount": 75.00,
+  "currency": "USD",
+  "createdAt": "2026-07-15T19:05:00Z"
+}
+```
+
+**Planned order statuses:** `PENDING`, `COMPLETED`, `CANCELLED`, `REFUNDED`
+
+### Tickets
+
+Future endpoints for accessing purchased tickets.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/api/tickets` | Authenticated | List the current user's tickets |
+| GET | `/api/tickets/{ticketId}` | Authenticated | Get ticket details / QR data |
+| POST | `/api/tickets/{ticketId}/transfer` | Authenticated | Transfer a ticket to another user |
+| POST | `/api/admin/tickets/{ticketId}/validate` | ADMIN | Validate a ticket at the door |
+
+**Planned ticket response:**
+```json
+{
+  "id": "e5f6a7b8-c9d0-1234-efab-345678901234",
+  "orderId": "d4e5f6a7-b8c9-0123-defa-234567890123",
+  "eventId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "seatId": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  "holderEmail": "user@example.com",
+  "status": "VALID",
+  "qrCode": "base64-encoded-qr-data",
+  "issuedAt": "2026-07-15T19:05:00Z"
+}
+```
+
+**Planned ticket statuses:** `VALID`, `USED`, `TRANSFERRED`, `CANCELLED`
+
+---
+
+## Frontend Alignment Notes
+
+The frontend currently integrates with:
+- Auth endpoints (login/register)
+- Events listing (`GET /api/events`)
+- Analytics dashboard (`GET /api/analytics/dashboard`)
+- Admin user management (`GET /api/admin/users`, `PATCH .../promote`)
+
+**Not yet wired in the frontend:** Seats, holds, release, confirm. These are backend-ready and awaiting the seat selection / checkout UI.

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -108,7 +108,7 @@ Tokens are obtained from the Auth endpoints and expire after 15 minutes.
 |--------|------|------|-------------|
 | POST | `/api/events/{eventId}/holds` | Authenticated | Create a hold on 1-10 seats |
 | GET | `/api/holds` | Authenticated | List holds for a holder |
-| GET | `/api/holds/{holdId}` | Public | Get a single hold |
+| GET | `/api/holds/{holdId}` | Authenticated | Get a single hold |
 | POST | `/api/holds/{holdId}/release` | Authenticated | Release a hold (idempotent) |
 | POST | `/api/holds/{holdId}/confirm` | Authenticated | Confirm a hold (idempotent) |
 
@@ -121,17 +121,19 @@ Tokens are obtained from the Auth endpoints and expire after 15 minutes.
 }
 ```
 
-**Hold response:**
+**Hold response (array — one hold per seat):**
 ```json
-{
-  "id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
-  "seatId": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
-  "eventId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-  "holderId": "user-session-abc123",
-  "expiresAt": "2026-07-15T19:10:00Z",
-  "createdAt": "2026-07-15T19:00:00Z",
-  "status": "ACTIVE"
-}
+[
+  {
+    "id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+    "seatId": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+    "eventId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "holderId": "user-session-abc123",
+    "expiresAt": "2026-07-15T19:10:00Z",
+    "createdAt": "2026-07-15T19:00:00Z",
+    "status": "ACTIVE"
+  }
+]
 ```
 
 **Hold statuses:** `ACTIVE`, `CONFIRMED`, `EXPIRED`, `RELEASED`

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -179,69 +179,78 @@ All errors follow a consistent shape:
 
 ---
 
-## Planned Endpoints (Not Yet Implemented)
+## Orders
 
-### Orders
-
-Future endpoints for completing a purchase after confirming a hold.
+Endpoints for completing a purchase after confirming a hold.
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | POST | `/api/orders` | Authenticated | Create an order from confirmed holds |
 | GET | `/api/orders` | Authenticated | List the current user's orders |
 | GET | `/api/orders/{orderId}` | Authenticated | Get order details |
-| POST | `/api/orders/{orderId}/cancel` | Authenticated | Cancel an order (if refundable) |
-| GET | `/api/admin/orders` | ADMIN | List all orders (admin) |
 
-**Planned create order request:**
+**Create order request:**
 ```json
 {
-  "holdIds": ["c3d4e5f6-a7b8-9012-cdef-123456789012"],
-  "paymentMethod": "CARD"
+  "holdIds": ["c3d4e5f6-a7b8-9012-cdef-123456789012"]
 }
 ```
 
-**Planned order response:**
+**Order response:**
 ```json
 {
   "id": "d4e5f6a7-b8c9-0123-defa-234567890123",
   "userId": "d290f1ee-6c54-4b01-90e6-d701748f0851",
   "holdIds": ["c3d4e5f6-a7b8-9012-cdef-123456789012"],
   "status": "COMPLETED",
-  "totalAmount": 75.00,
+  "totalAmount": 0.00,
   "currency": "USD",
   "createdAt": "2026-07-15T19:05:00Z"
 }
 ```
 
-**Planned order statuses:** `PENDING`, `COMPLETED`, `CANCELLED`, `REFUNDED`
+**Order statuses:** `PENDING`, `COMPLETED`, `CANCELLED`, `REFUNDED`
 
 ### Tickets
 
-Future endpoints for accessing purchased tickets.
+Endpoints for accessing purchased tickets.
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | GET | `/api/tickets` | Authenticated | List the current user's tickets |
-| GET | `/api/tickets/{ticketId}` | Authenticated | Get ticket details / QR data |
-| POST | `/api/tickets/{ticketId}/transfer` | Authenticated | Transfer a ticket to another user |
-| POST | `/api/admin/tickets/{ticketId}/validate` | ADMIN | Validate a ticket at the door |
+| GET | `/api/tickets/{ticketId}` | Authenticated | Get ticket details |
 
-**Planned ticket response:**
+**Ticket response:**
 ```json
 {
   "id": "e5f6a7b8-c9d0-1234-efab-345678901234",
   "orderId": "d4e5f6a7-b8c9-0123-defa-234567890123",
   "eventId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "eventTitle": "Summer Music Festival",
+  "eventVenue": "Madison Square Garden",
+  "eventStartTime": "2026-07-15T19:00:00Z",
   "seatId": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  "seatSection": "Floor",
+  "seatRow": "A",
+  "seatNumber": "101",
   "holderEmail": "user@example.com",
   "status": "VALID",
-  "qrCode": "base64-encoded-qr-data",
   "issuedAt": "2026-07-15T19:05:00Z"
 }
 ```
 
-**Planned ticket statuses:** `VALID`, `USED`, `TRANSFERRED`, `CANCELLED`
+**Ticket statuses:** `VALID`, `USED`, `TRANSFERRED`, `CANCELLED`
+
+---
+
+## Planned Endpoints (Not Yet Implemented)
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/api/orders/{orderId}/cancel` | Authenticated | Cancel an order (if refundable) |
+| GET | `/api/admin/orders` | ADMIN | List all orders (admin) |
+| POST | `/api/tickets/{ticketId}/transfer` | Authenticated | Transfer a ticket to another user |
+| POST | `/api/admin/tickets/{ticketId}/validate` | ADMIN | Validate a ticket at the door |
 
 ---
 
@@ -252,5 +261,6 @@ The frontend currently integrates with:
 - Events listing (`GET /api/events`)
 - Analytics dashboard (`GET /api/analytics/dashboard`)
 - Admin user management (`GET /api/admin/users`, `PATCH .../promote`)
+- Tickets listing (`GET /api/tickets`) — My Tickets page
 
-**Not yet wired in the frontend:** Seats, holds, release, confirm. These are backend-ready and awaiting the seat selection / checkout UI.
+**Not yet wired in the frontend:** Seats, holds, release, confirm, order creation. These are backend-ready and awaiting the seat selection / checkout UI.

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -116,7 +116,7 @@ Tokens are obtained from the Auth endpoints and expire after 15 minutes.
 ```json
 {
   "seatIds": ["b2c3d4e5-f6a7-8901-bcde-f12345678901"],
-  "holderId": "user-session-abc123",
+  "holderId": "d290f1ee-6c54-4b01-90e6-d701748f0851",
   "durationMinutes": 10
 }
 ```
@@ -128,7 +128,7 @@ Tokens are obtained from the Auth endpoints and expire after 15 minutes.
     "id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
     "seatId": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
     "eventId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-    "holderId": "user-session-abc123",
+    "holderId": "d290f1ee-6c54-4b01-90e6-d701748f0851",
     "expiresAt": "2026-07-15T19:10:00Z",
     "createdAt": "2026-07-15T19:00:00Z",
     "status": "ACTIVE"

--- a/frontend/webpages/package-lock.json
+++ b/frontend/webpages/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.22.3",
         "react-scripts": "5.0.1",
+        "recharts": "^3.8.1",
         "web-vitals": "^2.1.4"
       }
     },
@@ -3407,6 +3408,42 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
@@ -3530,6 +3567,18 @@
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -3964,6 +4013,69 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "8.56.12",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
@@ -4260,6 +4372,12 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -6787,6 +6905,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -6879,6 +7118,12 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -7581,6 +7826,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -9750,6 +10005,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -14353,6 +14617,29 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -14518,6 +14805,52 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/recharts/node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/recursive-readdir": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
@@ -14541,6 +14874,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -14694,6 +15042,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -16446,6 +16800,12 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -16934,6 +17294,15 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -17006,6 +17375,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/w3c-hr-time": {

--- a/frontend/webpages/package.json
+++ b/frontend/webpages/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3",
     "react-scripts": "5.0.1",
+    "recharts": "^3.8.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/frontend/webpages/src/App.js
+++ b/frontend/webpages/src/App.js
@@ -9,6 +9,7 @@ import Login from './pages/Login';
 import Signup from './pages/Signup';
 import Events from './pages/Events';
 import Dashboard from './pages/Dashboard';
+import MyTickets from './pages/MyTickets';
 import AdminLayout from './admin/AdminLayout';
 import AdminDashboard from './admin/pages/AdminDashboard';
 import AdminEventsPage from './admin/pages/AdminEventsPage';
@@ -31,6 +32,7 @@ function App() {
             {/* Authenticated routes */}
             <Route element={<ProtectedRoute />}>
               <Route path="/dashboard" element={<Dashboard />} />
+              <Route path="/my-tickets" element={<MyTickets />} />
             </Route>
 
             {/* Admin routes */}

--- a/frontend/webpages/src/admin/components/EventsByVenueChart.js
+++ b/frontend/webpages/src/admin/components/EventsByVenueChart.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+
+function EventsByVenueChart({ data }) {
+  const chartData = data.map((v) => ({
+    name: v.venue.length > 15 ? v.venue.substring(0, 15) + '...' : v.venue,
+    count: v.count,
+  }));
+
+  return (
+    <Card sx={{ backgroundColor: 'background.paper', height: '100%' }}>
+      <CardContent>
+        <Typography variant="h6" sx={{ fontWeight: 600, mb: 1 }}>
+          Events by Venue
+        </Typography>
+        <ResponsiveContainer width="100%" height={320}>
+          <BarChart data={chartData}>
+            <XAxis dataKey="name" stroke="#b0b0b0" tick={{ fontSize: 12 }} />
+            <YAxis stroke="#b0b0b0" allowDecimals={false} />
+            <Tooltip contentStyle={{ backgroundColor: '#16213e', border: 'none', color: '#fff' }} />
+            <Bar dataKey="count" fill="#0f3460" radius={[4, 4, 0, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default EventsByVenueChart;

--- a/frontend/webpages/src/admin/components/HoldStatusChart.js
+++ b/frontend/webpages/src/admin/components/HoldStatusChart.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+
+const COLORS = { ACTIVE: '#2196f3', CONFIRMED: '#4caf50', EXPIRED: '#9e9e9e', RELEASED: '#ff9800' };
+
+function HoldStatusChart({ data }) {
+  const chartData = Object.entries(data).map(([name, value]) => ({ name, value }));
+
+  return (
+    <Card sx={{ backgroundColor: 'background.paper' }}>
+      <CardContent sx={{ p: 3 }}>
+        <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
+          Holds by Status
+        </Typography>
+        <div style={{ width: '100%', height: 300 }}>
+          <ResponsiveContainer>
+            <PieChart margin={{ top: 10, right: 10, bottom: 10, left: 10 }}>
+              <Pie data={chartData} dataKey="value" nameKey="name" cx="50%" cy="45%" outerRadius="70%" label={false}>
+                {chartData.map((entry) => (
+                  <Cell key={entry.name} fill={COLORS[entry.name] || '#8884d8'} />
+                ))}
+              </Pie>
+              <Tooltip />
+              <Legend wrapperStyle={{ paddingTop: 10 }} />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default HoldStatusChart;

--- a/frontend/webpages/src/admin/components/HoldsOverTimeChart.js
+++ b/frontend/webpages/src/admin/components/HoldsOverTimeChart.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts';
+
+function HoldsOverTimeChart({ data }) {
+  const chartData = data.map((d) => ({
+    date: d.date,
+    count: d.count,
+  }));
+
+  return (
+    <Card sx={{ backgroundColor: 'background.paper', height: '100%' }}>
+      <CardContent>
+        <Typography variant="h6" sx={{ fontWeight: 600, mb: 1 }}>
+          Holds Over Time (Last 30 Days)
+        </Typography>
+        <ResponsiveContainer width="100%" height={320}>
+          <LineChart data={chartData}>
+            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
+            <XAxis dataKey="date" stroke="#b0b0b0" tick={{ fontSize: 11 }} angle={-35} textAnchor="end" height={60} />
+            <YAxis stroke="#b0b0b0" allowDecimals={false} />
+            <Tooltip contentStyle={{ backgroundColor: '#16213e', border: 'none', color: '#fff' }} />
+            <Line type="monotone" dataKey="count" stroke="#e94560" strokeWidth={2} dot={{ r: 3 }} />
+          </LineChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default HoldsOverTimeChart;

--- a/frontend/webpages/src/admin/components/SeatStatusChart.js
+++ b/frontend/webpages/src/admin/components/SeatStatusChart.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+
+const COLORS = { AVAILABLE: '#4caf50', HELD: '#ff9800', BOOKED: '#e94560' };
+
+function SeatStatusChart({ data }) {
+  const chartData = Object.entries(data).map(([name, value]) => ({ name, value }));
+
+  return (
+    <Card sx={{ backgroundColor: 'background.paper' }}>
+      <CardContent sx={{ p: 3 }}>
+        <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
+          Seats by Status
+        </Typography>
+        <div style={{ width: '100%', height: 300 }}>
+          <ResponsiveContainer>
+            <PieChart margin={{ top: 10, right: 10, bottom: 10, left: 10 }}>
+              <Pie data={chartData} dataKey="value" nameKey="name" cx="50%" cy="45%" outerRadius="70%" label={false}>
+                {chartData.map((entry) => (
+                  <Cell key={entry.name} fill={COLORS[entry.name] || '#8884d8'} />
+                ))}
+              </Pie>
+              <Tooltip />
+              <Legend wrapperStyle={{ paddingTop: 10 }} />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default SeatStatusChart;

--- a/frontend/webpages/src/admin/components/SeatStatusChart.js
+++ b/frontend/webpages/src/admin/components/SeatStatusChart.js
@@ -4,7 +4,7 @@ import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 
-const COLORS = { AVAILABLE: '#4caf50', HELD: '#ff9800', BOOKED: '#e94560' };
+const COLORS = { AVAILABLE: '#4caf50', HELD: '#ff9800', BOOKED: '#e94560', SOLD: '#2196f3' };
 
 function SeatStatusChart({ data }) {
   const chartData = Object.entries(data).map(([name, value]) => ({ name, value }));

--- a/frontend/webpages/src/admin/components/TopEventsChart.js
+++ b/frontend/webpages/src/admin/components/TopEventsChart.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+
+function TopEventsChart({ data }) {
+  const chartData = data.map((e) => ({
+    name: e.eventTitle.length > 20 ? e.eventTitle.substring(0, 20) + '...' : e.eventTitle,
+    Available: e.available,
+    Held: e.held,
+    Booked: e.booked,
+  }));
+
+  const barHeight = Math.max(380, chartData.length * 50 + 80);
+
+  return (
+    <Card sx={{ backgroundColor: 'background.paper' }}>
+      <CardContent sx={{ p: 3 }}>
+        <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
+          Top Events by Bookings
+        </Typography>
+        <div style={{ width: '100%', height: barHeight }}>
+          <ResponsiveContainer>
+            <BarChart data={chartData} layout="vertical" margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
+              <XAxis type="number" stroke="#b0b0b0" allowDecimals={false} />
+              <YAxis type="category" dataKey="name" width={130} stroke="#b0b0b0" tick={{ fontSize: 12 }} />
+              <Tooltip contentStyle={{ backgroundColor: '#16213e', border: 'none', color: '#fff' }} />
+              <Legend />
+              <Bar dataKey="Booked" fill="#e94560" stackId="a" />
+              <Bar dataKey="Held" fill="#ff9800" stackId="a" />
+              <Bar dataKey="Available" fill="#4caf50" stackId="a" />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default TopEventsChart;

--- a/frontend/webpages/src/admin/components/TopEventsChart.js
+++ b/frontend/webpages/src/admin/components/TopEventsChart.js
@@ -10,6 +10,7 @@ function TopEventsChart({ data }) {
     Available: e.available,
     Held: e.held,
     Booked: e.booked,
+    Sold: e.sold,
   }));
 
   const barHeight = Math.max(380, chartData.length * 50 + 80);
@@ -27,6 +28,7 @@ function TopEventsChart({ data }) {
               <YAxis type="category" dataKey="name" width={130} stroke="#b0b0b0" tick={{ fontSize: 12 }} />
               <Tooltip contentStyle={{ backgroundColor: '#16213e', border: 'none', color: '#fff' }} />
               <Legend />
+              <Bar dataKey="Sold" fill="#2196f3" stackId="a" />
               <Bar dataKey="Booked" fill="#e94560" stackId="a" />
               <Bar dataKey="Held" fill="#ff9800" stackId="a" />
               <Bar dataKey="Available" fill="#4caf50" stackId="a" />

--- a/frontend/webpages/src/admin/components/UsersByRoleChart.js
+++ b/frontend/webpages/src/admin/components/UsersByRoleChart.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+
+const COLORS = { USER: '#2196f3', ADMIN: '#e94560' };
+
+function UsersByRoleChart({ data }) {
+  const chartData = Object.entries(data).map(([name, value]) => ({ name, value }));
+
+  return (
+    <Card sx={{ backgroundColor: 'background.paper' }}>
+      <CardContent sx={{ p: 3 }}>
+        <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
+          Users by Role
+        </Typography>
+        <div style={{ width: '100%', height: 300 }}>
+          <ResponsiveContainer>
+            <PieChart margin={{ top: 10, right: 10, bottom: 10, left: 10 }}>
+              <Pie data={chartData} dataKey="value" nameKey="name" cx="50%" cy="45%" outerRadius="70%" label={false}>
+                {chartData.map((entry) => (
+                  <Cell key={entry.name} fill={COLORS[entry.name] || '#8884d8'} />
+                ))}
+              </Pie>
+              <Tooltip />
+              <Legend wrapperStyle={{ paddingTop: 10 }} />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default UsersByRoleChart;

--- a/frontend/webpages/src/admin/pages/AdminDashboard.js
+++ b/frontend/webpages/src/admin/pages/AdminDashboard.js
@@ -2,67 +2,125 @@ import React, { useState, useEffect } from 'react';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
+import Alert from '@mui/material/Alert';
+import CircularProgress from '@mui/material/CircularProgress';
 import EventIcon from '@mui/icons-material/Event';
 import UpcomingIcon from '@mui/icons-material/CalendarMonth';
 import PeopleIcon from '@mui/icons-material/People';
+import ChairIcon from '@mui/icons-material/Chair';
+import ConfirmationNumberIcon from '@mui/icons-material/ConfirmationNumber';
+import PanToolIcon from '@mui/icons-material/PanTool';
+import PercentIcon from '@mui/icons-material/Percent';
 import StatsCard from '../components/StatsCard';
+import SeatStatusChart from '../components/SeatStatusChart';
+import HoldStatusChart from '../components/HoldStatusChart';
+import TopEventsChart from '../components/TopEventsChart';
+import HoldsOverTimeChart from '../components/HoldsOverTimeChart';
+import EventsByVenueChart from '../components/EventsByVenueChart';
+import UsersByRoleChart from '../components/UsersByRoleChart';
 import api from '../../api/client';
 
 function AdminDashboard() {
-  const [stats, setStats] = useState({ totalEvents: 0, upcomingEvents: 0, totalUsers: 0 });
+  const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
-    async function fetchStats() {
+    async function fetchAnalytics() {
       try {
-        const [allEvents, upcoming, users] = await Promise.all([
-          api.get('/api/events?size=1'),
-          api.get('/api/events?upcoming=true&size=1'),
-          api.get('/api/admin/users?size=1'),
-        ]);
-        setStats({
-          totalEvents: allEvents.totalElements || 0,
-          upcomingEvents: upcoming.totalElements || 0,
-          totalUsers: users.totalElements || 0,
-        });
+        const result = await api.get('/api/analytics/dashboard');
+        setData(result);
       } catch (err) {
-        console.error('Failed to fetch dashboard stats:', err);
+        console.error('Failed to fetch analytics:', err);
+        setError('Failed to load analytics data.');
       } finally {
         setLoading(false);
       }
     }
-    fetchStats();
+    fetchAnalytics();
   }, []);
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 400 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return <Alert severity="error" sx={{ mt: 2 }}>{error}</Alert>;
+  }
+
+  const { overview } = data;
 
   return (
     <Box>
       <Typography variant="h4" sx={{ mb: 3, fontWeight: 700 }}>
         Dashboard
       </Typography>
+
+      {/* Row 1: Overview Stats */}
+      <Grid container spacing={3} sx={{ mb: 3 }}>
+        <Grid item xs={12} sm={6} md={4} lg={4}>
+          <StatsCard title="Total Events" value={overview.totalEvents} icon={<EventIcon />} color="#e94560" />
+        </Grid>
+        <Grid item xs={12} sm={6} md={4} lg={4}>
+          <StatsCard title="Upcoming Events" value={overview.upcomingEvents} icon={<UpcomingIcon />} color="#0f3460" />
+        </Grid>
+        <Grid item xs={12} sm={6} md={4} lg={4}>
+          <StatsCard title="Total Users" value={overview.totalUsers} icon={<PeopleIcon />} color="#533483" />
+        </Grid>
+        <Grid item xs={12} sm={6} md={4} lg={4}>
+          <StatsCard title="Total Seats" value={overview.totalSeats} icon={<ChairIcon />} color="#2196f3" />
+        </Grid>
+        <Grid item xs={12} sm={6} md={4} lg={4}>
+          <StatsCard title="Booked Seats" value={overview.bookedSeats} icon={<ConfirmationNumberIcon />} color="#4caf50" />
+        </Grid>
+        <Grid item xs={12} sm={6} md={4} lg={4}>
+          <StatsCard title="Active Holds" value={overview.activeHolds} icon={<PanToolIcon />} color="#ff9800" />
+        </Grid>
+      </Grid>
+
+      {/* Row 2: Seat & Hold Status Pies */}
+      <Grid container spacing={3} sx={{ mb: 3 }}>
+        <Grid item xs={12} md={6}>
+          <SeatStatusChart data={data.seatsByStatus} />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <HoldStatusChart data={data.holdsByStatus} />
+        </Grid>
+      </Grid>
+
+      {/* Row 3: Top Events */}
+      <Grid container spacing={3} sx={{ mb: 3 }}>
+        <Grid item xs={12}>
+          <TopEventsChart data={data.topEventsByBookings} />
+        </Grid>
+      </Grid>
+
+      {/* Row 4: Holds Over Time & Events by Venue */}
+      <Grid container spacing={3} sx={{ mb: 3 }}>
+        <Grid item xs={12} md={7}>
+          <HoldsOverTimeChart data={data.holdsPerDay} />
+        </Grid>
+        <Grid item xs={12} md={5}>
+          <EventsByVenueChart data={data.eventsByVenue} />
+        </Grid>
+      </Grid>
+
+      {/* Row 5: Confirmation Rate & Users by Role */}
       <Grid container spacing={3}>
         <Grid item xs={12} sm={6} md={4}>
           <StatsCard
-            title="Total Events"
-            value={loading ? '...' : stats.totalEvents}
-            icon={<EventIcon />}
-            color="#e94560"
+            title="Hold Confirmation Rate"
+            value={`${data.holdConfirmationRate}%`}
+            icon={<PercentIcon />}
+            color="#4caf50"
           />
         </Grid>
-        <Grid item xs={12} sm={6} md={4}>
-          <StatsCard
-            title="Upcoming Events"
-            value={loading ? '...' : stats.upcomingEvents}
-            icon={<UpcomingIcon />}
-            color="#0f3460"
-          />
-        </Grid>
-        <Grid item xs={12} sm={6} md={4}>
-          <StatsCard
-            title="Total Users"
-            value={loading ? '...' : stats.totalUsers}
-            icon={<PeopleIcon />}
-            color="#533483"
-          />
+        <Grid item xs={12} sm={6} md={8}>
+          <UsersByRoleChart data={data.usersByRole} />
         </Grid>
       </Grid>
     </Box>

--- a/frontend/webpages/src/admin/pages/AdminDashboard.js
+++ b/frontend/webpages/src/admin/pages/AdminDashboard.js
@@ -10,6 +10,7 @@ import PeopleIcon from '@mui/icons-material/People';
 import ChairIcon from '@mui/icons-material/Chair';
 import ConfirmationNumberIcon from '@mui/icons-material/ConfirmationNumber';
 import PanToolIcon from '@mui/icons-material/PanTool';
+import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
 import PercentIcon from '@mui/icons-material/Percent';
 import StatsCard from '../components/StatsCard';
 import SeatStatusChart from '../components/SeatStatusChart';
@@ -79,6 +80,9 @@ function AdminDashboard() {
         </Grid>
         <Grid item xs={12} sm={6} md={4} lg={4}>
           <StatsCard title="Active Holds" value={overview.activeHolds} icon={<PanToolIcon />} color="#ff9800" />
+        </Grid>
+        <Grid item xs={12} sm={6} md={4} lg={4}>
+          <StatsCard title="Sold Seats" value={overview.soldSeats} icon={<ShoppingCartIcon />} color="#2196f3" />
         </Grid>
       </Grid>
 

--- a/frontend/webpages/src/admin/pages/AdminEventsPage.js
+++ b/frontend/webpages/src/admin/pages/AdminEventsPage.js
@@ -45,7 +45,7 @@ function AdminEventsPage() {
     setLoading(true);
     setError('');
     try {
-      const params = new URLSearchParams({ page: page.toString(), size: rowsPerPage.toString() });
+      const params = new URLSearchParams({ page: page.toString(), size: rowsPerPage.toString(), upcoming: 'false' });
       if (search.trim()) params.set('title', search.trim());
       const data = await api.get(`/api/events?${params}`);
       setEvents(data.content || []);

--- a/frontend/webpages/src/admin/pages/AdminSeatsPage.js
+++ b/frontend/webpages/src/admin/pages/AdminSeatsPage.js
@@ -23,6 +23,7 @@ const statusColors = {
   AVAILABLE: 'success',
   HELD: 'warning',
   BOOKED: 'error',
+  SOLD: 'primary',
 };
 
 function AdminSeatsPage() {

--- a/frontend/webpages/src/components/Navbar.js
+++ b/frontend/webpages/src/components/Navbar.js
@@ -26,6 +26,7 @@ function Navbar() {
 
         {user && (
           <>
+            <NavLink to="/my-tickets">My Tickets</NavLink>
             <NavLink to="/dashboard">Dashboard</NavLink>
             {user.role === 'ADMIN' && (
               <NavLink to="/admin">Admin Panel</NavLink>

--- a/frontend/webpages/src/components/TicketCard.js
+++ b/frontend/webpages/src/components/TicketCard.js
@@ -1,0 +1,40 @@
+import React from 'react';
+
+function TicketCard({ ticket }) {
+  const statusClass = ticket.status.toLowerCase();
+
+  return (
+    <div className="ticket-card">
+      <div className="ticket-card-header">
+        <h3>{ticket.eventTitle}</h3>
+        <span className={`ticket-status ${statusClass}`}>{ticket.status}</span>
+      </div>
+      <div className="ticket-card-details">
+        <div>
+          <span className="label">Venue</span>
+          <span>{ticket.eventVenue}</span>
+        </div>
+        <div>
+          <span className="label">Date</span>
+          <span>{new Date(ticket.eventStartTime).toLocaleString()}</span>
+        </div>
+        <div className="ticket-card-seat">
+          <span>
+            <span className="label">Section</span>
+            {ticket.seatSection}
+          </span>
+          <span>
+            <span className="label">Row</span>
+            {ticket.seatRow}
+          </span>
+          <span>
+            <span className="label">Seat</span>
+            {ticket.seatNumber}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default TicketCard;

--- a/frontend/webpages/src/pages/MyTickets.js
+++ b/frontend/webpages/src/pages/MyTickets.js
@@ -1,0 +1,46 @@
+import React, { useState, useEffect } from 'react';
+import api from '../api/client';
+import TicketCard from '../components/TicketCard';
+import '../styles/MyTickets.css';
+
+function MyTickets() {
+  const [tickets, setTickets] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    api.get('/api/tickets')
+      .then((data) => {
+        setTickets(data || []);
+      })
+      .catch((err) => {
+        setError(err.message || 'Failed to load tickets');
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, []);
+
+  if (loading) return <div className="loading">Loading tickets...</div>;
+  if (error) return <div className="error-message">{error}</div>;
+
+  return (
+    <div className="my-tickets">
+      <h2>My Tickets</h2>
+      {tickets.length === 0 ? (
+        <div className="tickets-empty">
+          <p>You don't have any tickets yet.</p>
+          <p>Browse events and purchase tickets to see them here.</p>
+        </div>
+      ) : (
+        <div className="tickets-grid">
+          {tickets.map((ticket) => (
+            <TicketCard key={ticket.id} ticket={ticket} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default MyTickets;

--- a/frontend/webpages/src/styles/MyTickets.css
+++ b/frontend/webpages/src/styles/MyTickets.css
@@ -1,0 +1,100 @@
+.my-tickets {
+  padding: 2rem;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.my-tickets h2 {
+  margin-bottom: 1.5rem;
+}
+
+.tickets-empty {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: #888;
+}
+
+.tickets-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 1.25rem;
+}
+
+.ticket-card {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 1.25rem;
+  background: #fff;
+  transition: box-shadow 0.2s;
+}
+
+.ticket-card:hover {
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+}
+
+.ticket-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 0.75rem;
+}
+
+.ticket-card-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.ticket-status {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.ticket-status.valid {
+  background: #e6f4ea;
+  color: #1e7e34;
+}
+
+.ticket-status.used {
+  background: #e8e8e8;
+  color: #666;
+}
+
+.ticket-status.cancelled {
+  background: #fce8e6;
+  color: #c5221f;
+}
+
+.ticket-status.transferred {
+  background: #e8f0fe;
+  color: #1a73e8;
+}
+
+.ticket-card-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  color: #444;
+}
+
+.ticket-card-details .label {
+  color: #888;
+  font-size: 0.8rem;
+}
+
+.ticket-card-seat {
+  display: flex;
+  gap: 1rem;
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid #f0f0f0;
+}
+
+.ticket-card-seat span {
+  display: flex;
+  flex-direction: column;
+}


### PR DESCRIPTION
## Summary
- **Order module**: Create orders from confirmed holds with atomic seat status transition (BOOKED → SOLD), user-scoped listing/retrieval, validation, and integration tests
- **Ticket module**: Automatic ticket issuance on order creation, user-scoped listing/detail endpoints with ownership enforcement, and integration tests covering auth, full flow, and cross-user isolation
- **My Tickets frontend**: New page at `/my-tickets` with ticket cards showing event details, seat info, and status badges. Protected route with navbar link for authenticated users
- **Analytics SOLD tracking**: Added SOLD seat count to dashboard overview, seat status pie chart, and top events bar chart across backend and admin frontend
- **Bug fixes**: Hardened GlobalExceptionHandler with `DataIntegrityViolationException` (409) and catch-all (500) handlers to prevent unhandled errors surfacing as misleading 403s. Fixed admin events page to show all events instead of only upcoming

## Test plan
- [x] All 92 backend tests pass (11 new for orders/tickets)
- [x] Frontend builds cleanly
- [x] Full end-to-end flow verified: create seat → hold → confirm → order → ticket issued → visible on `/my-tickets`
- [x] Seat status correctly transitions AVAILABLE → HELD → BOOKED → SOLD
- [x] User isolation verified: tickets only visible to their owner
- [x] Admin dashboard displays SOLD stats correctly
- [ ] Verify on existing databases: `seats_status_check` constraint may need updating to include SOLD (`ALTER TABLE seats DROP CONSTRAINT seats_status_check; ALTER TABLE seats ADD CONSTRAINT seats_status_check CHECK (status IN ('AVAILABLE', 'HELD', 'BOOKED', 'SOLD'));`). Fresh databases are unaffected.