### PR TITLE
Add event detail page with seat listing

### DIFF
--- a/backend/src/main/java/com/fairtix/auth/application/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/fairtix/auth/application/JwtAuthenticationFilter.java
@@ -38,24 +38,24 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     String token = authHeader.substring(7);
 
-    if (jwtService.isTokenValid(token)
-        && SecurityContextHolder.getContext().getAuthentication() == null) {
-
+    if (SecurityContextHolder.getContext().getAuthentication() == null) {
       try {
         Claims claims = jwtService.extractAllClaims(token);
-        String email = claims.getSubject();
-        UUID userId = UUID.fromString(claims.get("userId", String.class));
-        String role = claims.get("role", String.class);
+        if (claims.getExpiration().after(new java.util.Date())) {
+          String email = claims.getSubject();
+          UUID userId = UUID.fromString(claims.get("userId", String.class));
+          String role = claims.get("role", String.class);
 
-        CustomUserPrincipal principal = new CustomUserPrincipal(
-            userId, email, "", List.of(new SimpleGrantedAuthority("ROLE_" + role)));
+          CustomUserPrincipal principal = new CustomUserPrincipal(
+              userId, email, "", List.of(new SimpleGrantedAuthority("ROLE_" + role)));
 
-        UsernamePasswordAuthenticationToken authToken =
-            new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+          UsernamePasswordAuthenticationToken authToken =
+              new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
 
-        SecurityContextHolder.getContext().setAuthentication(authToken);
+          SecurityContextHolder.getContext().setAuthentication(authToken);
+        }
       } catch (Exception e) {
-        // Malformed or missing claims — treat as unauthenticated
+        // Malformed, expired, or missing claims — treat as unauthenticated
       }
     }
 

--- a/backend/src/main/java/com/fairtix/auth/application/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/fairtix/auth/application/JwtAuthenticationFilter.java
@@ -1,26 +1,26 @@
 package com.fairtix.auth.application;
 
+import com.fairtix.auth.domain.CustomUserPrincipal;
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.*;
 import jakarta.servlet.http.*;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
 
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final JwtService jwtService;
-  private final UserDetailsService userDetailsService;
 
-  public JwtAuthenticationFilter(JwtService jwtService,
-      UserDetailsService userDetailsService) {
+  public JwtAuthenticationFilter(JwtService jwtService) {
     this.jwtService = jwtService;
-    this.userDetailsService = userDetailsService;
   }
 
   @Override
@@ -37,20 +37,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     String token = authHeader.substring(7);
-    String email = jwtService.extractEmail(token);
 
-    if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+    if (jwtService.isTokenValid(token)
+        && SecurityContextHolder.getContext().getAuthentication() == null) {
 
-      UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+      Claims claims = jwtService.extractAllClaims(token);
+      String email = claims.getSubject();
+      UUID userId = UUID.fromString(claims.get("userId", String.class));
+      String role = claims.get("role", String.class);
 
-      if (jwtService.isTokenValid(token)) {
-        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
-            userDetails,
-            null,
-            userDetails.getAuthorities());
+      CustomUserPrincipal principal = new CustomUserPrincipal(
+          userId, email, "", List.of(new SimpleGrantedAuthority("ROLE_" + role)));
 
-        SecurityContextHolder.getContext().setAuthentication(authToken);
-      }
+      UsernamePasswordAuthenticationToken authToken =
+          new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+
+      SecurityContextHolder.getContext().setAuthentication(authToken);
     }
 
     filterChain.doFilter(request, response);

--- a/backend/src/main/java/com/fairtix/auth/application/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/fairtix/auth/application/JwtAuthenticationFilter.java
@@ -41,18 +41,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     if (jwtService.isTokenValid(token)
         && SecurityContextHolder.getContext().getAuthentication() == null) {
 
-      Claims claims = jwtService.extractAllClaims(token);
-      String email = claims.getSubject();
-      UUID userId = UUID.fromString(claims.get("userId", String.class));
-      String role = claims.get("role", String.class);
+      try {
+        Claims claims = jwtService.extractAllClaims(token);
+        String email = claims.getSubject();
+        UUID userId = UUID.fromString(claims.get("userId", String.class));
+        String role = claims.get("role", String.class);
 
-      CustomUserPrincipal principal = new CustomUserPrincipal(
-          userId, email, "", List.of(new SimpleGrantedAuthority("ROLE_" + role)));
+        CustomUserPrincipal principal = new CustomUserPrincipal(
+            userId, email, "", List.of(new SimpleGrantedAuthority("ROLE_" + role)));
 
-      UsernamePasswordAuthenticationToken authToken =
-          new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+        UsernamePasswordAuthenticationToken authToken =
+            new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
 
-      SecurityContextHolder.getContext().setAuthentication(authToken);
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+      } catch (Exception e) {
+        // Malformed or missing claims — treat as unauthenticated
+      }
     }
 
     filterChain.doFilter(request, response);

--- a/backend/src/main/java/com/fairtix/auth/domain/CustomUserPrincipal.java
+++ b/backend/src/main/java/com/fairtix/auth/domain/CustomUserPrincipal.java
@@ -1,0 +1,22 @@
+package com.fairtix.auth.domain;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.Collection;
+import java.util.UUID;
+
+public class CustomUserPrincipal extends User {
+
+  private final UUID userId;
+
+  public CustomUserPrincipal(UUID userId, String email, String password,
+      Collection<? extends GrantedAuthority> authorities) {
+    super(email, password, authorities);
+    this.userId = userId;
+  }
+
+  public UUID getUserId() {
+    return userId;
+  }
+}

--- a/backend/src/main/java/com/fairtix/inventory/api/SeatHoldController.java
+++ b/backend/src/main/java/com/fairtix/inventory/api/SeatHoldController.java
@@ -1,5 +1,6 @@
 package com.fairtix.inventory.api;
 
+import com.fairtix.auth.domain.CustomUserPrincipal;
 import com.fairtix.inventory.application.SeatHoldService;
 import com.fairtix.inventory.domain.HoldStatus;
 import com.fairtix.inventory.dto.CreateHoldRequest;
@@ -9,11 +10,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.annotation.security.PermitAll;
 import jakarta.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -24,6 +25,9 @@ import java.util.UUID;
  *
  * <p>Holds expire automatically after a configurable duration. Confirm and release
  * operations are idempotent — safe to retry without side effects.
+ *
+ * <p>All hold operations are bound to the authenticated user — the owner is
+ * derived from the JWT, never accepted from the client.
  */
 @Tag(name = "Holds", description = "Seat hold lifecycle")
 @RestController
@@ -39,14 +43,15 @@ public class SeatHoldController {
      * Places a hold on one or more seats for an event.
      *
      * POST /api/events/{eventId}/holds
-     * Body: { "seatIds": ["..."], "holderId": "...", "durationMinutes": 10 }
+     * Body: { "seatIds": ["..."], "durationMinutes": 10 }
      *
-     * @param eventId the event whose seats to hold
-     * @param request seat IDs, holder identifier, and optional duration
+     * @param eventId   the event whose seats to hold
+     * @param request   seat IDs and optional duration
+     * @param principal the authenticated user (injected from JWT)
      * @return 201 Created with the list of created holds
      */
     @Operation(summary = "Create a seat hold",
-            description = "Authenticated. Temporarily reserves 1–10 seats for the holder.")
+            description = "Authenticated. Temporarily reserves 1–10 seats for the caller.")
     @ApiResponse(responseCode = "201", description = "Holds created")
     @ApiResponse(responseCode = "400", description = "Validation error")
     @ApiResponse(responseCode = "409", description = "One or more seats not available")
@@ -55,65 +60,67 @@ public class SeatHoldController {
     @ResponseStatus(HttpStatus.CREATED)
     public List<SeatHoldResponse> createHold(
             @PathVariable UUID eventId,
-            @Valid @RequestBody CreateHoldRequest request) {
+            @Valid @RequestBody CreateHoldRequest request,
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
         return seatHoldService
-                .createHold(eventId, request.seatIds(), request.holderId(), request.durationMinutes())
+                .createHold(eventId, request.seatIds(), principal.getUserId(), request.durationMinutes())
                 .stream()
                 .map(SeatHoldResponse::from)
                 .toList();
     }
 
     /**
-     * Lists holds for a given holder, optionally filtered by status.
+     * Lists holds for the authenticated user, optionally filtered by status.
      *
-     * GET /api/holds?holderId=...&amp;status=ACTIVE
+     * GET /api/holds?status=ACTIVE
      *
-     * @param holderId the holder's identifier
-     * @param status   hold status filter (defaults to ACTIVE)
+     * @param principal the authenticated user (injected from JWT)
+     * @param status    hold status filter (defaults to ACTIVE)
      * @return 200 OK with the matching holds (empty list if none)
      */
-    @Operation(summary = "List holds for a holder",
-            description = "Returns holds matching the given holder and status.")
+    @Operation(summary = "List holds for the authenticated user",
+            description = "Returns holds matching the authenticated user and status.")
     @ApiResponse(responseCode = "200", description = "List of holds")
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/api/holds")
     public List<SeatHoldResponse> listHolds(
-            @Parameter(description = "Holder identifier") @RequestParam String holderId,
+            @AuthenticationPrincipal CustomUserPrincipal principal,
             @Parameter(description = "Filter by status") @RequestParam(defaultValue = "ACTIVE") HoldStatus status) {
-        return seatHoldService.listHolds(holderId, status)
+        return seatHoldService.listHolds(principal.getUserId(), status)
                 .stream()
                 .map(SeatHoldResponse::from)
                 .toList();
     }
 
     /**
-     * Returns hold details visible only to the original holder.
+     * Returns hold details visible only to the original owner.
      *
-     * GET /api/holds/{holdId}?holderId=...
+     * GET /api/holds/{holdId}
      *
-     * @param holdId   the hold's unique ID
-     * @param holderId the holder's identifier (ownership check)
-     * @return 200 OK with the hold, or 404 if not found for this holder
+     * @param holdId    the hold's unique ID
+     * @param principal the authenticated user (injected from JWT)
+     * @return 200 OK with the hold, or 404 if not found for this user
      */
     @Operation(summary = "Get a hold by ID",
-            description = "Returns a single hold, scoped to the given holder.")
+            description = "Returns a single hold owned by the authenticated user.")
     @ApiResponse(responseCode = "200", description = "Hold found")
-    @ApiResponse(responseCode = "404", description = "Hold not found for this holder")
-    @PermitAll
+    @ApiResponse(responseCode = "404", description = "Hold not found for this user")
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/api/holds/{holdId}")
     public SeatHoldResponse getHold(
             @PathVariable UUID holdId,
-            @Parameter(description = "Holder identifier") @RequestParam String holderId) {
-        return SeatHoldResponse.from(seatHoldService.getHold(holdId, holderId));
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
+        return SeatHoldResponse.from(seatHoldService.getHold(holdId, principal.getUserId()));
     }
 
     /**
      * Releases an active hold, freeing the seat for others.
      * Idempotent: calling release on an already-RELEASED hold returns 200.
      *
-     * POST /api/holds/{holdId}/release?holderId=...
+     * POST /api/holds/{holdId}/release
      *
-     * @param holdId   the hold to release
-     * @param holderId the holder's identifier (ownership check)
+     * @param holdId    the hold to release
+     * @param principal the authenticated user (injected from JWT)
      * @return 200 OK with the updated hold
      */
     @Operation(summary = "Release a hold",
@@ -125,18 +132,18 @@ public class SeatHoldController {
     @PostMapping("/api/holds/{holdId}/release")
     public SeatHoldResponse releaseHold(
             @PathVariable UUID holdId,
-            @Parameter(description = "Holder identifier") @RequestParam String holderId) {
-        return SeatHoldResponse.from(seatHoldService.releaseHold(holdId, holderId));
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
+        return SeatHoldResponse.from(seatHoldService.releaseHold(holdId, principal.getUserId()));
     }
 
     /**
      * Confirms an active hold, transitioning the seat to BOOKED.
      * Idempotent: calling confirm on an already-CONFIRMED hold returns 200.
      *
-     * POST /api/holds/{holdId}/confirm?holderId=...
+     * POST /api/holds/{holdId}/confirm
      *
-     * @param holdId   the hold to confirm
-     * @param holderId the holder's identifier (ownership check)
+     * @param holdId    the hold to confirm
+     * @param principal the authenticated user (injected from JWT)
      * @return 200 OK with the updated hold
      */
     @Operation(summary = "Confirm a hold",
@@ -148,7 +155,7 @@ public class SeatHoldController {
     @PostMapping("/api/holds/{holdId}/confirm")
     public SeatHoldResponse confirmHold(
             @PathVariable UUID holdId,
-            @Parameter(description = "Holder identifier") @RequestParam String holderId) {
-        return SeatHoldResponse.from(seatHoldService.confirmHold(holdId, holderId));
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
+        return SeatHoldResponse.from(seatHoldService.confirmHold(holdId, principal.getUserId()));
     }
 }

--- a/backend/src/main/java/com/fairtix/inventory/application/SeatHoldNotFoundException.java
+++ b/backend/src/main/java/com/fairtix/inventory/application/SeatHoldNotFoundException.java
@@ -1,7 +1,7 @@
 package com.fairtix.inventory.application;
 
 /**
- * Thrown when a hold is not found for the given id + holderId combination.
+ * Thrown when a hold is not found for the given id + ownerId combination.
  * Mapped to HTTP 404 by {@link com.fairtix.config.GlobalExceptionHandler}.
  */
 public class SeatHoldNotFoundException extends RuntimeException {

--- a/backend/src/main/java/com/fairtix/inventory/application/SeatHoldService.java
+++ b/backend/src/main/java/com/fairtix/inventory/application/SeatHoldService.java
@@ -35,6 +35,9 @@ public class SeatHoldService {
   @Value("${holds.max-active-per-holder:5}")
   private int maxActivePerHolder;
 
+  @Value("${holds.max-seats-per-hold:10}")
+  private int maxSeatsPerHold;
+
   public SeatHoldService(SeatRepository seatRepository,
       SeatHoldRepository seatHoldRepository,
       EventRepository eventRepository) {
@@ -89,10 +92,10 @@ public class SeatHoldService {
     List<UUID> sortedIds = seatIds.stream().distinct().sorted().toList();
 
     // Enforce configurable max seats per hold before acquiring any locks
-    if (sortedIds.size() > maxActivePerHolder) {
+    if (sortedIds.size() > maxSeatsPerHold) {
       throw new IllegalArgumentException(
           "Too many seats requested for a single hold: requested " + sortedIds.size()
-              + ", maximum is " + maxActivePerHolder);
+              + ", maximum is " + maxSeatsPerHold);
     }
     // Lock all seats in one batch query — ORDER BY s.id matches our sort above
     List<Seat> lockedSeats = seatRepository.findAndLockByIdIn(sortedIds);

--- a/backend/src/main/java/com/fairtix/inventory/application/SeatHoldService.java
+++ b/backend/src/main/java/com/fairtix/inventory/application/SeatHoldService.java
@@ -58,25 +58,25 @@ public class SeatHoldService {
    *
    * @param eventId         the target event
    * @param seatIds         the seats to hold (duplicates are de-duped)
-   * @param holderId        opaque identifier for the holder
+   * @param ownerId         authenticated user's ID
    * @param durationMinutes requested hold length; clamped and defaulted
    *                        server-side
    * @return the created {@link SeatHold} records
    */
   @Transactional
   public List<SeatHold> createHold(UUID eventId, List<UUID> seatIds,
-      String holderId, Integer durationMinutes) {
+      UUID ownerId, Integer durationMinutes) {
 
     if (!eventRepository.existsById(eventId)) {
       throw new IllegalArgumentException("Event not found: " + eventId);
     }
 
     // Soft limit: reject before acquiring any locks
-    long activeCount = seatHoldRepository.countByHolderIdAndStatus(holderId, HoldStatus.ACTIVE);
+    long activeCount = seatHoldRepository.countByOwnerIdAndStatus(ownerId, HoldStatus.ACTIVE);
     long requestedDistinctSeats = seatIds.stream().distinct().count();
     if (activeCount + requestedDistinctSeats > maxActivePerHolder) {
       throw new SeatHoldConflictException(
-          "Hold limit reached: " + holderId + " already has " + activeCount + " active hold(s)");
+          "Hold limit reached: " + ownerId + " already has " + activeCount + " active hold(s)");
     }
 
     // Clamp duration: null → default, >max → max
@@ -130,7 +130,7 @@ public class SeatHoldService {
         .collect(Collectors.toMap(Seat::getId, Function.identity()));
     List<SeatHold> holds = seatIds.stream()
         .distinct()
-        .map(id -> new SeatHold(seatById.get(id), holderId, expiresAt))
+        .map(id -> new SeatHold(seatById.get(id), ownerId, expiresAt))
         .toList();
     return seatHoldRepository.saveAll(holds);
   }
@@ -142,13 +142,13 @@ public class SeatHoldService {
    * Idempotent: calling release on a hold that is already RELEASED returns
    * the hold unchanged (200 OK) instead of throwing.
    *
-   * @param holdId   the hold to release
-   * @param holderId must match the holder who created the hold
+   * @param holdId  the hold to release
+   * @param ownerId must match the authenticated user who created the hold
    * @return the (possibly unchanged) {@link SeatHold}
    */
   @Transactional
-  public SeatHold releaseHold(UUID holdId, String holderId) {
-    SeatHold hold = seatHoldRepository.findByIdAndHolderId(holdId, holderId)
+  public SeatHold releaseHold(UUID holdId, UUID ownerId) {
+    SeatHold hold = seatHoldRepository.findByIdAndOwnerId(holdId, ownerId)
         .orElseThrow(() -> new SeatHoldNotFoundException("Hold not found: " + holdId));
 
     // Idempotent: already released is a no-op
@@ -177,13 +177,13 @@ public class SeatHoldService {
    * Idempotent: calling confirm on a hold that is already CONFIRMED returns
    * the hold unchanged (200 OK) instead of throwing.
    *
-   * @param holdId   the hold to confirm
-   * @param holderId must match the holder who created the hold
+   * @param holdId  the hold to confirm
+   * @param ownerId must match the authenticated user who created the hold
    * @return the (possibly unchanged) {@link SeatHold}
    */
   @Transactional
-  public SeatHold confirmHold(UUID holdId, String holderId) {
-    SeatHold hold = seatHoldRepository.findByIdAndHolderId(holdId, holderId)
+  public SeatHold confirmHold(UUID holdId, UUID ownerId) {
+    SeatHold hold = seatHoldRepository.findByIdAndOwnerId(holdId, ownerId)
         .orElseThrow(() -> new SeatHoldNotFoundException("Hold not found: " + holdId));
 
     // Idempotent: already confirmed is a no-op
@@ -210,25 +210,25 @@ public class SeatHoldService {
   /**
    * Returns hold details for the given holder.
    *
-   * @param holdId   the hold id
-   * @param holderId must match the holder who created the hold
+   * @param holdId  the hold id
+   * @param ownerId must match the authenticated user who created the hold
    * @return the {@link SeatHold}
    */
   @Transactional
-  public SeatHold getHold(UUID holdId, String holderId) {
-    return seatHoldRepository.findByIdAndHolderId(holdId, holderId)
+  public SeatHold getHold(UUID holdId, UUID ownerId) {
+    return seatHoldRepository.findByIdAndOwnerId(holdId, ownerId)
         .orElseThrow(() -> new SeatHoldNotFoundException("Hold not found: " + holdId));
   }
 
   /**
    * Lists all holds for the given holder, filtered by status.
    *
-   * @param holderId the holder to query for
-   * @param status   the desired hold status (e.g. ACTIVE)
+   * @param ownerId the authenticated user's ID
+   * @param status  the desired hold status (e.g. ACTIVE)
    * @return matching holds, possibly empty
    */
   @Transactional
-  public List<SeatHold> listHolds(String holderId, HoldStatus status) {
-    return seatHoldRepository.findAllByHolderIdAndStatus(holderId, status);
+  public List<SeatHold> listHolds(UUID ownerId, HoldStatus status) {
+    return seatHoldRepository.findAllByOwnerIdAndStatus(ownerId, status);
   }
 }

--- a/backend/src/main/java/com/fairtix/inventory/domain/SeatHold.java
+++ b/backend/src/main/java/com/fairtix/inventory/domain/SeatHold.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 @Entity
 @Table(name = "seat_holds", indexes = {
     @Index(name = "idx_hold_status_expires", columnList = "status, expires_at"),
-    @Index(name = "idx_hold_holder_id",      columnList = "holder_id")
+    @Index(name = "idx_hold_owner_id",       columnList = "owner_id")
 })
 public class SeatHold {
 
@@ -20,8 +20,8 @@ public class SeatHold {
   @JoinColumn(name = "seat_id", nullable = false)
   private Seat seat;
 
-  @Column(nullable = false, name = "holder_id")
-  private String holderId;
+  @Column(nullable = false, name = "owner_id")
+  private UUID ownerId;
 
   @Column(nullable = false, name = "expires_at")
   private Instant expiresAt;
@@ -33,9 +33,9 @@ public class SeatHold {
   @Column(nullable = false, name = "created_at", updatable = false)
   private Instant createdAt;
 
-  public SeatHold(Seat seat, String holderId, Instant expiresAt) {
+  public SeatHold(Seat seat, UUID ownerId, Instant expiresAt) {
     this.seat = seat;
-    this.holderId = holderId;
+    this.ownerId = ownerId;
     this.expiresAt = expiresAt;
     this.status = HoldStatus.ACTIVE;
     this.createdAt = Instant.now();
@@ -52,8 +52,8 @@ public class SeatHold {
     return seat;
   }
 
-  public String getHolderId() {
-    return holderId;
+  public UUID getOwnerId() {
+    return ownerId;
   }
 
   public Instant getExpiresAt() {

--- a/backend/src/main/java/com/fairtix/inventory/dto/CreateHoldRequest.java
+++ b/backend/src/main/java/com/fairtix/inventory/dto/CreateHoldRequest.java
@@ -12,7 +12,7 @@ import java.util.UUID;
  * Request payload for creating a seat hold.
  *
  * <p>Bean-validation enforces a hard upper bound of 10 seats per request.
- * The service also enforces {@code holds.max-seats-per-hold} and
+ * The service also enforces {@code holds.max-active-per-holder} and
  * {@code holds.max-duration-minutes} so the limits hold even for direct calls.
  *
  * <p>The hold owner is derived from the authenticated user's JWT — it is

--- a/backend/src/main/java/com/fairtix/inventory/dto/CreateHoldRequest.java
+++ b/backend/src/main/java/com/fairtix/inventory/dto/CreateHoldRequest.java
@@ -2,7 +2,6 @@ package com.fairtix.inventory.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 
@@ -16,8 +15,10 @@ import java.util.UUID;
  * The service also enforces {@code holds.max-seats-per-hold} and
  * {@code holds.max-duration-minutes} so the limits hold even for direct calls.
  *
+ * <p>The hold owner is derived from the authenticated user's JWT — it is
+ * never accepted from the client.
+ *
  * @param seatIds         the seats to hold (1-10 items)
- * @param holderId        opaque identifier for the holder (session/user id)
  * @param durationMinutes how long the hold lasts; server default when null
  */
 @Schema(description = "Payload for creating a temporary seat hold")
@@ -28,11 +29,6 @@ public record CreateHoldRequest(
         @NotEmpty(message = "At least one seat is required")
         @Size(max = 10, message = "Cannot request more than 10 seats per hold")
         List<UUID> seatIds,
-
-        @Schema(description = "User ID of the holder (must match authenticated user for order creation)",
-                example = "d290f1ee-6c54-4b01-90e6-d701748f0851")
-        @NotBlank(message = "holderId must not be blank")
-        String holderId,
 
         @Schema(description = "Hold duration in minutes (server default if omitted, max 60)",
                 example = "10")

--- a/backend/src/main/java/com/fairtix/inventory/dto/SeatHoldResponse.java
+++ b/backend/src/main/java/com/fairtix/inventory/dto/SeatHoldResponse.java
@@ -14,7 +14,7 @@ import java.util.UUID;
  * @param id        the unique hold id
  * @param seatId    the held seat
  * @param eventId   the event the seat belongs to
- * @param holderId  the holder identifier
+ * @param ownerId   the owner's user ID
  * @param expiresAt when the hold expires (UTC)
  * @param createdAt when the hold was created (UTC)
  * @param status    the current hold status
@@ -27,8 +27,8 @@ public record SeatHoldResponse(
         UUID seatId,
         @Schema(description = "Event ID", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
         UUID eventId,
-        @Schema(description = "Holder identifier (user ID)", example = "d290f1ee-6c54-4b01-90e6-d701748f0851")
-        String holderId,
+        @Schema(description = "Owner user ID", example = "d290f1ee-6c54-4b01-90e6-d701748f0851")
+        UUID ownerId,
         @Schema(description = "Hold expiry time in UTC", example = "2026-07-15T19:10:00Z")
         Instant expiresAt,
         @Schema(description = "Hold creation time in UTC", example = "2026-07-15T19:00:00Z")
@@ -47,7 +47,7 @@ public record SeatHoldResponse(
                 hold.getId(),
                 hold.getSeat().getId(),
                 hold.getSeat().getEvent().getId(),
-                hold.getHolderId(),
+                hold.getOwnerId(),
                 hold.getExpiresAt(),
                 hold.getCreatedAt(),
                 hold.getStatus());

--- a/backend/src/main/java/com/fairtix/inventory/infrastructure/SeatHoldRepository.java
+++ b/backend/src/main/java/com/fairtix/inventory/infrastructure/SeatHoldRepository.java
@@ -21,7 +21,7 @@ public interface SeatHoldRepository extends JpaRepository<SeatHold, UUID> {
   @Query(value = "SELECT CAST(sh.created_at AS DATE) AS hold_date, COUNT(*) FROM seat_holds sh WHERE sh.created_at >= :since GROUP BY CAST(sh.created_at AS DATE) ORDER BY hold_date", nativeQuery = true)
   List<Object[]> countHoldsPerDay(@Param("since") Instant since);
 
-  Optional<SeatHold> findByIdAndHolderId(UUID id, String holderId);
+  Optional<SeatHold> findByIdAndOwnerId(UUID id, UUID ownerId);
 
   Optional<SeatHold> findBySeat_IdAndStatus(UUID seatId, HoldStatus status);
 
@@ -32,9 +32,9 @@ public interface SeatHoldRepository extends JpaRepository<SeatHold, UUID> {
    */
   Page<SeatHold> findAllByStatusAndExpiresAtBefore(HoldStatus status, Instant now, Pageable pageable);
 
-  /** Soft-limit: count how many active holds a holder currently has. */
-  long countByHolderIdAndStatus(String holderId, HoldStatus status);
+  /** Soft-limit: count how many active holds an owner currently has. */
+  long countByOwnerIdAndStatus(UUID ownerId, HoldStatus status);
 
-  /** List-holds endpoint: all holds for a holder filtered by status. */
-  List<SeatHold> findAllByHolderIdAndStatus(String holderId, HoldStatus status);
+  /** List-holds endpoint: all holds for an owner filtered by status. */
+  List<SeatHold> findAllByOwnerIdAndStatus(UUID ownerId, HoldStatus status);
 }

--- a/backend/src/main/java/com/fairtix/orders/api/OrderController.java
+++ b/backend/src/main/java/com/fairtix/orders/api/OrderController.java
@@ -1,10 +1,9 @@
 package com.fairtix.orders.api;
 
+import com.fairtix.auth.domain.CustomUserPrincipal;
 import com.fairtix.orders.application.OrderService;
 import com.fairtix.orders.dto.CreateOrderRequest;
 import com.fairtix.orders.dto.OrderResponse;
-import com.fairtix.users.domain.User;
-import com.fairtix.users.infrastructure.UserRepository;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -13,9 +12,7 @@ import jakarta.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.server.ResponseStatusException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,11 +24,9 @@ import java.util.UUID;
 public class OrderController {
 
     private final OrderService orderService;
-    private final UserRepository userRepository;
 
-    public OrderController(OrderService orderService, UserRepository userRepository) {
+    public OrderController(OrderService orderService) {
         this.orderService = orderService;
-        this.userRepository = userRepository;
     }
 
     @Operation(summary = "Create an order from confirmed holds")
@@ -40,18 +35,16 @@ public class OrderController {
     @PostMapping("/api/orders")
     @ResponseStatus(HttpStatus.CREATED)
     public OrderResponse createOrder(
-            @AuthenticationPrincipal UserDetails principal,
+            @AuthenticationPrincipal CustomUserPrincipal principal,
             @Valid @RequestBody CreateOrderRequest request) {
-        UUID userId = resolveUserId(principal);
-        return OrderResponse.from(orderService.createOrder(userId, request.holdIds()));
+        return OrderResponse.from(orderService.createOrder(principal.getUserId(), request.holdIds()));
     }
 
     @Operation(summary = "List the current user's orders")
     @ApiResponse(responseCode = "200", description = "List of orders")
     @GetMapping("/api/orders")
-    public List<OrderResponse> listOrders(@AuthenticationPrincipal UserDetails principal) {
-        UUID userId = resolveUserId(principal);
-        return orderService.listOrders(userId).stream()
+    public List<OrderResponse> listOrders(@AuthenticationPrincipal CustomUserPrincipal principal) {
+        return orderService.listOrders(principal.getUserId()).stream()
                 .map(OrderResponse::from)
                 .toList();
     }
@@ -61,16 +54,8 @@ public class OrderController {
     @ApiResponse(responseCode = "404", description = "Order not found")
     @GetMapping("/api/orders/{orderId}")
     public OrderResponse getOrder(
-            @AuthenticationPrincipal UserDetails principal,
+            @AuthenticationPrincipal CustomUserPrincipal principal,
             @PathVariable UUID orderId) {
-        UUID userId = resolveUserId(principal);
-        return OrderResponse.from(orderService.getOrder(orderId, userId));
-    }
-
-    private UUID resolveUserId(UserDetails principal) {
-        User user = userRepository.findByEmail(principal.getUsername())
-                .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.UNAUTHORIZED, "Authenticated user not found"));
-        return user.getId();
+        return OrderResponse.from(orderService.getOrder(orderId, principal.getUserId()));
     }
 }

--- a/backend/src/main/java/com/fairtix/orders/application/OrderService.java
+++ b/backend/src/main/java/com/fairtix/orders/application/OrderService.java
@@ -47,7 +47,7 @@ public class OrderService {
 
     // Validate all holds exist, belong to this user, and are CONFIRMED
     List<SeatHold> holds = holdIds.stream()
-        .map(holdId -> seatHoldRepository.findByIdAndHolderId(holdId, userId.toString())
+        .map(holdId -> seatHoldRepository.findByIdAndOwnerId(holdId, userId)
             .orElseThrow(() -> new IllegalArgumentException(
                 "Hold not found or does not belong to you: " + holdId)))
         .toList();

--- a/backend/src/main/java/com/fairtix/tickets/api/TicketController.java
+++ b/backend/src/main/java/com/fairtix/tickets/api/TicketController.java
@@ -1,19 +1,15 @@
 package com.fairtix.tickets.api;
 
+import com.fairtix.auth.domain.CustomUserPrincipal;
 import com.fairtix.tickets.application.TicketService;
 import com.fairtix.tickets.dto.TicketResponse;
-import com.fairtix.users.domain.User;
-import com.fairtix.users.infrastructure.UserRepository;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.server.ResponseStatusException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -25,19 +21,16 @@ import java.util.UUID;
 public class TicketController {
 
     private final TicketService ticketService;
-    private final UserRepository userRepository;
 
-    public TicketController(TicketService ticketService, UserRepository userRepository) {
+    public TicketController(TicketService ticketService) {
         this.ticketService = ticketService;
-        this.userRepository = userRepository;
     }
 
     @Operation(summary = "List the current user's tickets")
     @ApiResponse(responseCode = "200", description = "List of tickets")
     @GetMapping("/api/tickets")
-    public List<TicketResponse> listTickets(@AuthenticationPrincipal UserDetails principal) {
-        UUID userId = resolveUserId(principal);
-        return ticketService.listTickets(userId).stream()
+    public List<TicketResponse> listTickets(@AuthenticationPrincipal CustomUserPrincipal principal) {
+        return ticketService.listTickets(principal.getUserId()).stream()
                 .map(TicketResponse::from)
                 .toList();
     }
@@ -47,16 +40,8 @@ public class TicketController {
     @ApiResponse(responseCode = "404", description = "Ticket not found")
     @GetMapping("/api/tickets/{ticketId}")
     public TicketResponse getTicket(
-            @AuthenticationPrincipal UserDetails principal,
+            @AuthenticationPrincipal CustomUserPrincipal principal,
             @PathVariable UUID ticketId) {
-        UUID userId = resolveUserId(principal);
-        return TicketResponse.from(ticketService.getTicket(ticketId, userId));
-    }
-
-    private UUID resolveUserId(UserDetails principal) {
-        User user = userRepository.findByEmail(principal.getUsername())
-                .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.UNAUTHORIZED, "Authenticated user not found"));
-        return user.getId();
+        return TicketResponse.from(ticketService.getTicket(ticketId, principal.getUserId()));
     }
 }

--- a/backend/src/main/java/com/fairtix/users/application/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/fairtix/users/application/CustomUserDetailsService.java
@@ -1,9 +1,13 @@
 package com.fairtix.users.application;
 
+import com.fairtix.auth.domain.CustomUserPrincipal;
 import com.fairtix.users.domain.User;
 import com.fairtix.users.infrastructure.UserRepository;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.*;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class CustomUserDetailsService implements UserDetailsService {
@@ -21,11 +25,10 @@ public class CustomUserDetailsService implements UserDetailsService {
     User user = repository.findByEmail(email)
         .orElseThrow(() -> new UsernameNotFoundException("User not found"));
 
-    return org.springframework.security.core.userdetails.User
-        .builder()
-        .username(user.getEmail())
-        .password(user.getPassword())
-        .authorities("ROLE_" + user.getRole().name())
-        .build();
+    return new CustomUserPrincipal(
+        user.getId(),
+        user.getEmail(),
+        user.getPassword(),
+        List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name())));
   }
 }

--- a/backend/src/test/java/com/fairtix/auth/WithMockPrincipal.java
+++ b/backend/src/test/java/com/fairtix/auth/WithMockPrincipal.java
@@ -1,0 +1,40 @@
+package com.fairtix.auth;
+
+import com.fairtix.auth.domain.CustomUserPrincipal;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+
+/**
+ * Test utility that creates a {@link RequestPostProcessor} setting a
+ * {@link CustomUserPrincipal} in the security context — needed because
+ * {@code @WithMockUser} produces a standard Spring Security principal
+ * which cannot be cast to our custom type.
+ */
+public final class WithMockPrincipal {
+
+    private WithMockPrincipal() {
+    }
+
+    public static RequestPostProcessor user(UUID userId, String email, String role) {
+        CustomUserPrincipal principal = new CustomUserPrincipal(
+                userId, email, "",
+                List.of(new SimpleGrantedAuthority("ROLE_" + role)));
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+        return authentication(auth);
+    }
+
+    public static RequestPostProcessor user(UUID userId, String email) {
+        return user(userId, email, "USER");
+    }
+
+    public static RequestPostProcessor admin(UUID userId, String email) {
+        return user(userId, email, "ADMIN");
+    }
+}

--- a/backend/src/test/java/com/fairtix/inventory/api/SeatHoldControllerTest.java
+++ b/backend/src/test/java/com/fairtix/inventory/api/SeatHoldControllerTest.java
@@ -1,11 +1,11 @@
 package com.fairtix.inventory.api;
 
+import com.fairtix.auth.WithMockPrincipal;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,7 +14,6 @@ import org.springframework.web.context.WebApplicationContext;
 import java.util.UUID;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -40,6 +39,7 @@ class SeatHoldControllerTest {
   private MockMvc mockMvc;
 
   private static final String CREATE_URL = "/api/events/{eventId}/holds";
+  private static final UUID TEST_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000099");
 
   @BeforeEach
   void setUpMockMvc() {
@@ -53,16 +53,15 @@ class SeatHoldControllerTest {
   // -------------------------------------------------------------------------
 
   @Test
-  @WithMockUser(roles = "ADMIN")
   void createHold_emptySeatIds_returns400WithValidationError() throws Exception {
     String body = """
         {
-          "seatIds":  [],
-          "holderId": "user-1"
+          "seatIds":  []
         }
         """;
 
     mockMvc.perform(post(CREATE_URL, UUID.randomUUID())
+        .with(WithMockPrincipal.admin(TEST_USER_ID, "admin@test.com"))
         .contentType(MediaType.APPLICATION_JSON)
         .content(body))
         .andExpect(status().isBadRequest())
@@ -73,15 +72,13 @@ class SeatHoldControllerTest {
   }
 
   @Test
-  @WithMockUser(roles = "ADMIN")
   void createHold_missingSeatIds_returns400WithValidationError() throws Exception {
     String body = """
-        {
-          "holderId": "user-1"
-        }
+        {}
         """;
 
     mockMvc.perform(post(CREATE_URL, UUID.randomUUID())
+        .with(WithMockPrincipal.admin(TEST_USER_ID, "admin@test.com"))
         .contentType(MediaType.APPLICATION_JSON)
         .content(body))
         .andExpect(status().isBadRequest())
@@ -89,35 +86,16 @@ class SeatHoldControllerTest {
   }
 
   @Test
-  @WithMockUser(roles = "ADMIN")
-  void createHold_blankHolderId_returns400WithValidationError() throws Exception {
-    String body = """
-        {
-          "seatIds":  ["%s"],
-          "holderId": "   "
-        }
-        """.formatted(UUID.randomUUID());
-
-    mockMvc.perform(post(CREATE_URL, UUID.randomUUID())
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(body))
-        .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
-        .andExpect(jsonPath("$.message").value(containsString("holderId")));
-  }
-
-  @Test
-  @WithMockUser(roles = "ADMIN")
   void createHold_durationZero_returns400WithValidationError() throws Exception {
     String body = """
         {
           "seatIds":         ["%s"],
-          "holderId":        "user-1",
           "durationMinutes": 0
         }
         """.formatted(UUID.randomUUID());
 
     mockMvc.perform(post(CREATE_URL, UUID.randomUUID())
+        .with(WithMockPrincipal.admin(TEST_USER_ID, "admin@test.com"))
         .contentType(MediaType.APPLICATION_JSON)
         .content(body))
         .andExpect(status().isBadRequest())
@@ -126,18 +104,15 @@ class SeatHoldControllerTest {
   }
 
   @Test
-  @WithMockUser(roles = "ADMIN")
   void createHold_nonExistentEvent_returns400WithBadRequest() throws Exception {
-    // Valid body but event doesn't exist → IllegalArgumentException → 400
-    // BAD_REQUEST
     String body = """
         {
-          "seatIds":  ["%s"],
-          "holderId": "user-1"
+          "seatIds":  ["%s"]
         }
         """.formatted(UUID.randomUUID());
 
     mockMvc.perform(post(CREATE_URL, UUID.randomUUID())
+        .with(WithMockPrincipal.admin(TEST_USER_ID, "admin@test.com"))
         .contentType(MediaType.APPLICATION_JSON)
         .content(body))
         .andExpect(status().isBadRequest())
@@ -147,16 +122,15 @@ class SeatHoldControllerTest {
   }
 
   @Test
-  @WithMockUser(roles = "ADMIN")
   void errorResponse_alwaysContainsRequiredFields() throws Exception {
     String body = """
         {
-          "seatIds":  [],
-          "holderId": "user-1"
+          "seatIds":  []
         }
         """;
 
     mockMvc.perform(post(CREATE_URL, UUID.randomUUID())
+        .with(WithMockPrincipal.admin(TEST_USER_ID, "admin@test.com"))
         .contentType(MediaType.APPLICATION_JSON)
         .content(body))
         .andExpect(status().isBadRequest())
@@ -175,8 +149,7 @@ class SeatHoldControllerTest {
   void createHold_unauthenticated_returns403() throws Exception {
     String body = """
         {
-          "seatIds":  ["%s"],
-          "holderId": "user-1"
+          "seatIds":  ["%s"]
         }
         """.formatted(UUID.randomUUID());
 

--- a/backend/src/test/java/com/fairtix/inventory/application/SeatHoldServiceTest.java
+++ b/backend/src/test/java/com/fairtix/inventory/application/SeatHoldServiceTest.java
@@ -35,6 +35,9 @@ class SeatHoldServiceTest {
   private Event testEvent;
   private Seat testSeat;
 
+  private static final UUID USER_1 = UUID.fromString("00000000-0000-0000-0000-000000000001");
+  private static final UUID USER_2 = UUID.fromString("00000000-0000-0000-0000-000000000002");
+
   @BeforeEach
   void setUp() {
     testEvent = eventRepository.save(
@@ -43,18 +46,18 @@ class SeatHoldServiceTest {
   }
 
   // -------------------------------------------------------------------------
-  // Original tests (kept intact)
+  // Original tests (updated for UUID ownerId)
   // -------------------------------------------------------------------------
 
   @Test
   void holdingASeatSucceeds() {
     List<SeatHold> holds = seatHoldService.createHold(
-        testEvent.getId(), List.of(testSeat.getId()), "user-1", 10);
+        testEvent.getId(), List.of(testSeat.getId()), USER_1, 10);
 
     assertThat(holds).hasSize(1);
     SeatHold hold = holds.get(0);
     assertThat(hold.getStatus()).isEqualTo(HoldStatus.ACTIVE);
-    assertThat(hold.getHolderId()).isEqualTo("user-1");
+    assertThat(hold.getOwnerId()).isEqualTo(USER_1);
     assertThat(hold.getExpiresAt()).isAfter(Instant.now());
 
     Seat updatedSeat = seatRepository.findById(testSeat.getId()).orElseThrow();
@@ -64,10 +67,10 @@ class SeatHoldServiceTest {
   @Test
   void holdingTheSameSeatTwiceReturnsConflict() {
     seatHoldService.createHold(
-        testEvent.getId(), List.of(testSeat.getId()), "user-1", 10);
+        testEvent.getId(), List.of(testSeat.getId()), USER_1, 10);
 
     assertThatThrownBy(() -> seatHoldService.createHold(
-        testEvent.getId(), List.of(testSeat.getId()), "user-2", 10))
+        testEvent.getId(), List.of(testSeat.getId()), USER_2, 10))
         .isInstanceOf(SeatHoldConflictException.class)
         .hasMessageContaining("not available");
   }
@@ -77,7 +80,7 @@ class SeatHoldServiceTest {
     testSeat.setStatus(SeatStatus.HELD);
     seatRepository.save(testSeat);
 
-    SeatHold expiredHold = new SeatHold(testSeat, "user-1", Instant.now().minusSeconds(60));
+    SeatHold expiredHold = new SeatHold(testSeat, USER_1, Instant.now().minusSeconds(60));
     seatHoldRepository.save(expiredHold);
 
     scheduler.expireHolds();
@@ -96,10 +99,10 @@ class SeatHoldServiceTest {
   @Test
   void releasingAnAlreadyReleasedHoldIsIdempotent() {
     SeatHold hold = seatHoldService.createHold(
-        testEvent.getId(), List.of(testSeat.getId()), "user-1", 10).get(0);
+        testEvent.getId(), List.of(testSeat.getId()), USER_1, 10).get(0);
 
-    SeatHold firstRelease  = seatHoldService.releaseHold(hold.getId(), "user-1");
-    SeatHold secondRelease = seatHoldService.releaseHold(hold.getId(), "user-1");
+    SeatHold firstRelease  = seatHoldService.releaseHold(hold.getId(), USER_1);
+    SeatHold secondRelease = seatHoldService.releaseHold(hold.getId(), USER_1);
 
     assertThat(firstRelease.getStatus()).isEqualTo(HoldStatus.RELEASED);
     assertThat(secondRelease.getStatus()).isEqualTo(HoldStatus.RELEASED);
@@ -111,10 +114,10 @@ class SeatHoldServiceTest {
   @Test
   void confirmingAnAlreadyConfirmedHoldIsIdempotent() {
     SeatHold hold = seatHoldService.createHold(
-        testEvent.getId(), List.of(testSeat.getId()), "user-1", 10).get(0);
+        testEvent.getId(), List.of(testSeat.getId()), USER_1, 10).get(0);
 
-    SeatHold firstConfirm  = seatHoldService.confirmHold(hold.getId(), "user-1");
-    SeatHold secondConfirm = seatHoldService.confirmHold(hold.getId(), "user-1");
+    SeatHold firstConfirm  = seatHoldService.confirmHold(hold.getId(), USER_1);
+    SeatHold secondConfirm = seatHoldService.confirmHold(hold.getId(), USER_1);
 
     assertThat(firstConfirm.getStatus()).isEqualTo(HoldStatus.CONFIRMED);
     assertThat(secondConfirm.getStatus()).isEqualTo(HoldStatus.CONFIRMED);
@@ -130,7 +133,7 @@ class SeatHoldServiceTest {
   void durationIsClampedToMaxDurationMinutes() {
     // Request a hold 10× longer than the allowed maximum
     List<SeatHold> holds = seatHoldService.createHold(
-        testEvent.getId(), List.of(testSeat.getId()), "user-1", 600);
+        testEvent.getId(), List.of(testSeat.getId()), USER_1, 600);
 
     Instant hold60MinBound = Instant.now().plusSeconds(60 * 60L + 5); // 60 min + 5 s slack
     assertThat(holds.get(0).getExpiresAt()).isBefore(hold60MinBound);
@@ -142,16 +145,16 @@ class SeatHoldServiceTest {
 
   @Test
   void exceedingMaxActiveHoldsPerHolderThrowsConflict() {
-    // Create 2 seats so "user-1" can reach the limit
+    // Create 2 seats so USER_1 can reach the limit
     Seat extraSeat = seatRepository.save(new Seat(testEvent, "Floor", "A", "102"));
 
-    seatHoldService.createHold(testEvent.getId(), List.of(testSeat.getId()), "user-1", 10);
-    seatHoldService.createHold(testEvent.getId(), List.of(extraSeat.getId()), "user-1", 10);
+    seatHoldService.createHold(testEvent.getId(), List.of(testSeat.getId()), USER_1, 10);
+    seatHoldService.createHold(testEvent.getId(), List.of(extraSeat.getId()), USER_1, 10);
 
     // Third seat — must be blocked by the active-hold limit
     Seat thirdSeat = seatRepository.save(new Seat(testEvent, "Floor", "A", "103"));
     assertThatThrownBy(() -> seatHoldService.createHold(
-        testEvent.getId(), List.of(thirdSeat.getId()), "user-1", 10))
+        testEvent.getId(), List.of(thirdSeat.getId()), USER_1, 10))
         .isInstanceOf(SeatHoldConflictException.class)
         .hasMessageContaining("Hold limit reached");
   }
@@ -160,13 +163,13 @@ class SeatHoldServiceTest {
   void holdLimitIsPerHolder_otherHolderCanStillHold() {
     Seat extraSeat = seatRepository.save(new Seat(testEvent, "Floor", "A", "102"));
 
-    seatHoldService.createHold(testEvent.getId(), List.of(testSeat.getId()), "user-1", 10);
-    seatHoldService.createHold(testEvent.getId(), List.of(extraSeat.getId()), "user-1", 10);
+    seatHoldService.createHold(testEvent.getId(), List.of(testSeat.getId()), USER_1, 10);
+    seatHoldService.createHold(testEvent.getId(), List.of(extraSeat.getId()), USER_1, 10);
 
-    // user-2 is unaffected by user-1's limit
+    // USER_2 is unaffected by USER_1's limit
     Seat thirdSeat = seatRepository.save(new Seat(testEvent, "Floor", "A", "103"));
     List<SeatHold> holds = seatHoldService.createHold(
-        testEvent.getId(), List.of(thirdSeat.getId()), "user-2", 10);
+        testEvent.getId(), List.of(thirdSeat.getId()), USER_2, 10);
     assertThat(holds).hasSize(1);
     assertThat(holds.get(0).getStatus()).isEqualTo(HoldStatus.ACTIVE);
   }
@@ -189,7 +192,7 @@ class SeatHoldServiceTest {
         : List.of(id2, id1);
 
     List<SeatHold> holds = seatHoldService.createHold(
-        testEvent.getId(), reversed, "user-1", 10);
+        testEvent.getId(), reversed, USER_1, 10);
 
     assertThat(holds).hasSize(2);
     assertThat(seatRepository.findById(id1).orElseThrow().getStatus()).isEqualTo(SeatStatus.HELD);
@@ -202,7 +205,7 @@ class SeatHoldServiceTest {
     List<SeatHold> holds = seatHoldService.createHold(
         testEvent.getId(),
         List.of(testSeat.getId(), testSeat.getId()),
-        "user-1", 10);
+        USER_1, 10);
 
     assertThat(holds).hasSize(1);
   }
@@ -220,7 +223,7 @@ class SeatHoldServiceTest {
     for (Seat seat : List.of(testSeat, seat2, seat3)) {
       seat.setStatus(SeatStatus.HELD);
       seatRepository.save(seat);
-      seatHoldRepository.save(new SeatHold(seat, "user-1", Instant.now().minusSeconds(60)));
+      seatHoldRepository.save(new SeatHold(seat, USER_1, Instant.now().minusSeconds(60)));
     }
 
     scheduler.expireHolds();
@@ -244,13 +247,44 @@ class SeatHoldServiceTest {
   void listHoldsReturnsOnlyActiveHoldsForHolder() {
     Seat seat2 = seatRepository.save(new Seat(testEvent, "Floor", "A", "102"));
 
-    // Two holds for user-1 (hits the limit of 2 for test props)
-    seatHoldService.createHold(testEvent.getId(), List.of(testSeat.getId()), "user-1", 10);
-    seatHoldService.createHold(testEvent.getId(), List.of(seat2.getId()),    "user-1", 10);
+    // Two holds for USER_1 (hits the limit of 2 for test props)
+    seatHoldService.createHold(testEvent.getId(), List.of(testSeat.getId()), USER_1, 10);
+    seatHoldService.createHold(testEvent.getId(), List.of(seat2.getId()),    USER_1, 10);
 
-    List<SeatHold> active = seatHoldService.listHolds("user-1", HoldStatus.ACTIVE);
+    List<SeatHold> active = seatHoldService.listHolds(USER_1, HoldStatus.ACTIVE);
     assertThat(active).hasSize(2);
     assertThat(active).allMatch(h -> h.getStatus() == HoldStatus.ACTIVE);
-    assertThat(active).allMatch(h -> h.getHolderId().equals("user-1"));
+    assertThat(active).allMatch(h -> h.getOwnerId().equals(USER_1));
+  }
+
+  // -------------------------------------------------------------------------
+  // Ownership isolation
+  // -------------------------------------------------------------------------
+
+  @Test
+  void cannotReleaseAnotherUsersHold() {
+    SeatHold hold = seatHoldService.createHold(
+        testEvent.getId(), List.of(testSeat.getId()), USER_1, 10).get(0);
+
+    assertThatThrownBy(() -> seatHoldService.releaseHold(hold.getId(), USER_2))
+        .isInstanceOf(SeatHoldNotFoundException.class);
+  }
+
+  @Test
+  void cannotConfirmAnotherUsersHold() {
+    SeatHold hold = seatHoldService.createHold(
+        testEvent.getId(), List.of(testSeat.getId()), USER_1, 10).get(0);
+
+    assertThatThrownBy(() -> seatHoldService.confirmHold(hold.getId(), USER_2))
+        .isInstanceOf(SeatHoldNotFoundException.class);
+  }
+
+  @Test
+  void cannotGetAnotherUsersHold() {
+    SeatHold hold = seatHoldService.createHold(
+        testEvent.getId(), List.of(testSeat.getId()), USER_1, 10).get(0);
+
+    assertThatThrownBy(() -> seatHoldService.getHold(hold.getId(), USER_2))
+        .isInstanceOf(SeatHoldNotFoundException.class);
   }
 }

--- a/backend/src/test/java/com/fairtix/orders/api/OrderControllerTest.java
+++ b/backend/src/test/java/com/fairtix/orders/api/OrderControllerTest.java
@@ -1,5 +1,6 @@
 package com.fairtix.orders.api;
 
+import com.fairtix.auth.WithMockPrincipal;
 import com.fairtix.events.domain.Event;
 import com.fairtix.events.infrastructure.EventRepository;
 import com.fairtix.inventory.domain.HoldStatus;
@@ -15,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
@@ -75,13 +75,13 @@ class OrderControllerTest {
   }
 
   @Test
-  @WithMockUser(username = "ordertest@example.com")
   void createOrder_emptyHoldIds_returns400() throws Exception {
     String body = """
         { "holdIds": [] }
         """;
 
     mockMvc.perform(post("/api/orders")
+            .with(WithMockPrincipal.user(testUser.getId(), testUser.getEmail()))
             .contentType(MediaType.APPLICATION_JSON)
             .content(body))
         .andExpect(status().isBadRequest())
@@ -89,13 +89,13 @@ class OrderControllerTest {
   }
 
   @Test
-  @WithMockUser(username = "ordertest@example.com")
   void createOrder_nonExistentHold_returns400() throws Exception {
     String body = """
         { "holdIds": ["00000000-0000-0000-0000-000000000001"] }
         """;
 
     mockMvc.perform(post("/api/orders")
+            .with(WithMockPrincipal.user(testUser.getId(), testUser.getEmail()))
             .contentType(MediaType.APPLICATION_JSON)
             .content(body))
         .andExpect(status().isBadRequest())
@@ -103,7 +103,6 @@ class OrderControllerTest {
   }
 
   @Test
-  @WithMockUser(username = "ordertest@example.com")
   void createOrder_withConfirmedHold_returns201() throws Exception {
     // Set up: event → seat → confirmed hold
     Event event = eventRepository.save(new Event("Test Concert", "Test Venue", Instant.now().plusSeconds(86400)));
@@ -111,7 +110,7 @@ class OrderControllerTest {
     seat.setStatus(SeatStatus.BOOKED);
     seat = seatRepository.save(seat);
 
-    SeatHold hold = new SeatHold(seat, testUser.getId().toString(), Instant.now().plusSeconds(600));
+    SeatHold hold = new SeatHold(seat, testUser.getId(), Instant.now().plusSeconds(600));
     hold.setStatus(HoldStatus.CONFIRMED);
     hold = seatHoldRepository.save(hold);
 
@@ -120,6 +119,7 @@ class OrderControllerTest {
         """.formatted(hold.getId());
 
     mockMvc.perform(post("/api/orders")
+            .with(WithMockPrincipal.user(testUser.getId(), testUser.getEmail()))
             .contentType(MediaType.APPLICATION_JSON)
             .content(body))
         .andExpect(status().isCreated())
@@ -129,9 +129,9 @@ class OrderControllerTest {
   }
 
   @Test
-  @WithMockUser(username = "ordertest@example.com")
   void listOrders_returnsEmptyWhenNone() throws Exception {
-    mockMvc.perform(get("/api/orders"))
+    mockMvc.perform(get("/api/orders")
+            .with(WithMockPrincipal.user(testUser.getId(), testUser.getEmail())))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.length()").value(0));
   }

--- a/backend/src/test/java/com/fairtix/tickets/api/TicketControllerTest.java
+++ b/backend/src/test/java/com/fairtix/tickets/api/TicketControllerTest.java
@@ -1,5 +1,6 @@
 package com.fairtix.tickets.api;
 
+import com.fairtix.auth.WithMockPrincipal;
 import com.fairtix.events.domain.Event;
 import com.fairtix.events.infrastructure.EventRepository;
 import com.fairtix.inventory.domain.HoldStatus;
@@ -19,7 +20,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
-import org.springframework.security.test.context.support.WithMockUser;
 
 import java.time.Instant;
 import java.util.List;
@@ -73,15 +73,14 @@ class TicketControllerTest {
   }
 
   @Test
-  @WithMockUser(username = "tickettest@example.com")
   void listTickets_returnsEmptyWhenNone() throws Exception {
-    mockMvc.perform(get("/api/tickets"))
+    mockMvc.perform(get("/api/tickets")
+            .with(WithMockPrincipal.user(testUser.getId(), testUser.getEmail())))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.length()").value(0));
   }
 
   @Test
-  @WithMockUser(username = "tickettest@example.com")
   void listTickets_returnsTicketsAfterOrder() throws Exception {
     // Set up: event → seat → confirmed hold → order → tickets
     Event event = eventRepository.save(new Event("Ticket Concert", "Ticket Venue", Instant.now().plusSeconds(86400)));
@@ -89,14 +88,15 @@ class TicketControllerTest {
     seat.setStatus(SeatStatus.BOOKED);
     seat = seatRepository.save(seat);
 
-    SeatHold hold = new SeatHold(seat, testUser.getId().toString(), Instant.now().plusSeconds(600));
+    SeatHold hold = new SeatHold(seat, testUser.getId(), Instant.now().plusSeconds(600));
     hold.setStatus(HoldStatus.CONFIRMED);
     hold = seatHoldRepository.save(hold);
 
     // Create the order (which issues tickets)
     orderService.createOrder(testUser.getId(), List.of(hold.getId()));
 
-    mockMvc.perform(get("/api/tickets"))
+    mockMvc.perform(get("/api/tickets")
+            .with(WithMockPrincipal.user(testUser.getId(), testUser.getEmail())))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.length()").value(1))
         .andExpect(jsonPath("$[0].eventTitle").value("Ticket Concert"))
@@ -107,15 +107,14 @@ class TicketControllerTest {
   }
 
   @Test
-  @WithMockUser(username = "tickettest@example.com")
   void getTicket_notFound_returns404() throws Exception {
-    mockMvc.perform(get("/api/tickets/{ticketId}", UUID.randomUUID()))
+    mockMvc.perform(get("/api/tickets/{ticketId}", UUID.randomUUID())
+            .with(WithMockPrincipal.user(testUser.getId(), testUser.getEmail())))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.code").value("RESOURCE_NOT_FOUND"));
   }
 
   @Test
-  @WithMockUser(username = "other@example.com")
   void getTicket_belongingToOtherUser_returns404() throws Exception {
     // Create another user to test ownership isolation
     User otherUser = new User();
@@ -129,14 +128,15 @@ class TicketControllerTest {
     seat.setStatus(SeatStatus.BOOKED);
     seat = seatRepository.save(seat);
 
-    SeatHold hold = new SeatHold(seat, testUser.getId().toString(), Instant.now().plusSeconds(600));
+    SeatHold hold = new SeatHold(seat, testUser.getId(), Instant.now().plusSeconds(600));
     hold.setStatus(HoldStatus.CONFIRMED);
     hold = seatHoldRepository.save(hold);
 
     orderService.createOrder(testUser.getId(), List.of(hold.getId()));
 
     // otherUser should see empty tickets, not testUser's
-    mockMvc.perform(get("/api/tickets"))
+    mockMvc.perform(get("/api/tickets")
+            .with(WithMockPrincipal.user(otherUser.getId(), otherUser.getEmail())))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.length()").value(0));
   }

--- a/frontend/webpages/src/App.js
+++ b/frontend/webpages/src/App.js
@@ -8,6 +8,7 @@ import Home from './pages/Home';
 import Login from './pages/Login';
 import Signup from './pages/Signup';
 import Events from './pages/Events';
+import EventDetail from './pages/EventDetail';
 import Dashboard from './pages/Dashboard';
 import MyTickets from './pages/MyTickets';
 import AdminLayout from './admin/AdminLayout';
@@ -26,6 +27,7 @@ function App() {
             {/* Public routes */}
             <Route path="/" element={<Home />} />
             <Route path="/events" element={<Events />} />
+            <Route path="/events/:eventId" element={<EventDetail />} />
             <Route path="/login" element={<Login />} />
             <Route path="/signup" element={<Signup />} />
 

--- a/frontend/webpages/src/pages/EventDetail.js
+++ b/frontend/webpages/src/pages/EventDetail.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import api from '../api/client';
 import '../styles/EventDetail.css';

--- a/frontend/webpages/src/pages/EventDetail.js
+++ b/frontend/webpages/src/pages/EventDetail.js
@@ -1,0 +1,136 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import api from '../api/client';
+import '../styles/EventDetail.css';
+
+function groupSeatsBySection(seats) {
+  const groups = {};
+  for (const seat of seats) {
+    const key = seat.section || 'General';
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(seat);
+  }
+  for (const key of Object.keys(groups)) {
+    groups[key].sort((a, b) =>
+      a.rowLabel.localeCompare(b.rowLabel) || a.seatNumber.localeCompare(b.seatNumber)
+    );
+  }
+  return groups;
+}
+
+function buildSummary(seats) {
+  const summary = {};
+  for (const seat of seats) {
+    summary[seat.status] = (summary[seat.status] || 0) + 1;
+  }
+  return summary;
+}
+
+function EventDetail() {
+  const { eventId } = useParams();
+  const [event, setEvent] = useState(null);
+  const [seats, setSeats] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const [eventData, seatsData] = await Promise.all([
+        api.get(`/api/events/${eventId}`),
+        api.get(`/api/events/${eventId}/seats`),
+      ]);
+      setEvent(eventData);
+      setSeats(seatsData || []);
+    } catch (err) {
+      setError(err.message || 'Failed to load event details.');
+    } finally {
+      setLoading(false);
+    }
+  }, [eventId]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  if (loading) return <div className="loading">Loading event details...</div>;
+  if (error) return (
+    <div className="event-detail">
+      <Link to="/events" className="event-detail-back">&larr; Back to Events</Link>
+      <div className="error-message">{error}</div>
+    </div>
+  );
+
+  const sectionGroups = groupSeatsBySection(seats);
+  const summary = buildSummary(seats);
+
+  return (
+    <div className="event-detail">
+      <Link to="/events" className="event-detail-back">&larr; Back to Events</Link>
+
+      <div className="event-detail-header">
+        <h2>{event.title}</h2>
+        <div className="event-detail-meta">
+          <span>{event.venue}</span>
+          <span>{new Date(event.startTime).toLocaleString()}</span>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
+        <div className="seat-summary">
+          <span className="seat-summary-chip total">{seats.length} total</span>
+          {summary.AVAILABLE > 0 && (
+            <span className="seat-summary-chip available">{summary.AVAILABLE} available</span>
+          )}
+          {summary.HELD > 0 && (
+            <span className="seat-summary-chip held">{summary.HELD} held</span>
+          )}
+          {summary.BOOKED > 0 && (
+            <span className="seat-summary-chip booked">{summary.BOOKED} booked</span>
+          )}
+          {summary.SOLD > 0 && (
+            <span className="seat-summary-chip sold">{summary.SOLD} sold</span>
+          )}
+        </div>
+        <button className="event-detail-refresh" onClick={fetchData}>Refresh</button>
+      </div>
+
+      {seats.length === 0 ? (
+        <div className="seats-empty">
+          <p>No seats listed for this event yet.</p>
+        </div>
+      ) : (
+        Object.entries(sectionGroups).map(([section, sectionSeats]) => (
+          <div key={section} className="seat-section-group">
+            <h3>{section}</h3>
+            <table className="seats-table">
+              <thead>
+                <tr>
+                  <th>Row</th>
+                  <th>Seat</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sectionSeats.map((seat) => (
+                  <tr key={seat.id}>
+                    <td>{seat.rowLabel}</td>
+                    <td>{seat.seatNumber}</td>
+                    <td>
+                      <span className={`seat-status ${seat.status.toLowerCase()}`}>
+                        {seat.status}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+export default EventDetail;

--- a/frontend/webpages/src/pages/Events.js
+++ b/frontend/webpages/src/pages/Events.js
@@ -1,5 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import api from '../api/client';
+import '../styles/Events.css';
 
 function Events() {
   const [events, setEvents] = useState([]);
@@ -23,19 +25,25 @@ function Events() {
   if (error) return <div className="error-message">{error}</div>;
 
   return (
-    <div style={{ padding: '2rem' }}>
+    <div className="events-page">
       <h2>Events</h2>
       {events.length === 0 ? (
-        <p>No events available.</p>
+        <div className="events-empty">
+          <p>No events available.</p>
+        </div>
       ) : (
-        <ul style={{ listStyle: 'none', padding: 0 }}>
+        <div className="events-grid">
           {events.map((event) => (
-            <li key={event.id} style={{ padding: '1rem', borderBottom: '1px solid #eee' }}>
+            <Link key={event.id} to={`/events/${event.id}`} className="event-card">
               <h3>{event.title}</h3>
-              <p>{event.venue} — {new Date(event.startTime).toLocaleString()}</p>
-            </li>
+              <div className="event-card-meta">
+                <span>{event.venue}</span>
+                <span>{new Date(event.startTime).toLocaleString()}</span>
+              </div>
+              <div className="event-card-action">View details &rarr;</div>
+            </Link>
           ))}
-        </ul>
+        </div>
       )}
     </div>
   );

--- a/frontend/webpages/src/styles/EventDetail.css
+++ b/frontend/webpages/src/styles/EventDetail.css
@@ -1,0 +1,177 @@
+.event-detail {
+  padding: 2rem;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.event-detail-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: #555;
+  text-decoration: none;
+  font-size: 0.9rem;
+  margin-bottom: 1.5rem;
+}
+
+.event-detail-back:hover {
+  color: #111;
+}
+
+.event-detail-header {
+  margin-bottom: 2rem;
+}
+
+.event-detail-header h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.8rem;
+}
+
+.event-detail-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  color: #555;
+  font-size: 0.95rem;
+}
+
+.event-detail-meta span {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.seat-section-group {
+  margin-bottom: 2rem;
+}
+
+.seat-section-group h3 {
+  font-size: 1.1rem;
+  margin: 0 0 0.75rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 2px solid #eee;
+}
+
+.seat-summary {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+}
+
+.seat-summary-chip {
+  display: inline-block;
+  padding: 0.25rem 0.7rem;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.seat-summary-chip.total {
+  background: #f0f0f0;
+  color: #444;
+}
+
+.seat-summary-chip.available {
+  background: #e6f4ea;
+  color: #1e7e34;
+}
+
+.seat-summary-chip.held {
+  background: #fff8e1;
+  color: #f9a825;
+}
+
+.seat-summary-chip.booked {
+  background: #fce8e6;
+  color: #c5221f;
+}
+
+.seat-summary-chip.sold {
+  background: #e8f0fe;
+  color: #1a73e8;
+}
+
+.seats-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.seats-table th,
+.seats-table td {
+  text-align: left;
+  padding: 0.65rem 1rem;
+}
+
+.seats-table th {
+  background: #fafafa;
+  font-size: 0.85rem;
+  color: #666;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  border-bottom: 2px solid #e0e0e0;
+}
+
+.seats-table tr:not(:last-child) td {
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.seats-table tr:hover td {
+  background: #fafafa;
+}
+
+.seat-status {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.seat-status.available {
+  background: #e6f4ea;
+  color: #1e7e34;
+}
+
+.seat-status.held {
+  background: #fff8e1;
+  color: #f9a825;
+}
+
+.seat-status.booked {
+  background: #fce8e6;
+  color: #c5221f;
+}
+
+.seat-status.sold {
+  background: #e8f0fe;
+  color: #1a73e8;
+}
+
+.seats-empty {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: #888;
+}
+
+.event-detail-refresh {
+  background: none;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.85rem;
+  color: #555;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.event-detail-refresh:hover {
+  border-color: #999;
+  color: #111;
+}

--- a/frontend/webpages/src/styles/Events.css
+++ b/frontend/webpages/src/styles/Events.css
@@ -1,0 +1,57 @@
+.events-page {
+  padding: 2rem;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.events-page h2 {
+  margin-bottom: 1.5rem;
+}
+
+.events-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.25rem;
+}
+
+.event-card {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 1.25rem;
+  background: #fff;
+  transition: box-shadow 0.2s, border-color 0.2s;
+}
+
+.event-card:hover {
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+  border-color: #bbb;
+}
+
+.event-card h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+}
+
+.event-card-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.event-card-action {
+  margin-top: 0.75rem;
+  font-size: 0.85rem;
+  color: #1a73e8;
+  font-weight: 500;
+}
+
+.events-empty {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: #888;
+}


### PR DESCRIPTION
## Summary
- Add new public `/events/:eventId` page displaying event info (title, venue, date) and all seats grouped by section with color-coded status badges (available/held/booked/sold) and a refresh button
- Upgrade `/events` listing from plain `<ul>` to a styled card grid with links to each event's detail page
- Wire up the new route in App.js

Closes #38

## Test plan
- [ ] Navigate to `/events` and verify events display as clickable cards
- [ ] Click an event card and verify it routes to `/events/:eventId`
- [ ] Verify event header shows title, venue, and date
- [ ] Verify seats are grouped by section with correct status colors
- [ ] Verify "Refresh" button re-fetches seat data
- [ ] Verify "Back to Events" link navigates back
- [ ] Verify the page handles events with no seats gracefully