### PR TITLE
Add pricing model for seats and introduce Flyway migrations

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -73,6 +73,15 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-flyway</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-database-postgresql</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <scope>runtime</scope>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>4.0.1</version>
+    <version>4.0.5</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>com.fairtix</groupId>

--- a/backend/src/main/java/com/fairtix/inventory/api/SeatController.java
+++ b/backend/src/main/java/com/fairtix/inventory/api/SeatController.java
@@ -60,7 +60,7 @@ public class SeatController {
                 eventId, request.section(), request.rowLabel(), request.seatNumber());
 
         return SeatResponse.from(
-                seatService.createSeat(eventId, request.section(), request.rowLabel(), request.seatNumber()));
+                seatService.createSeat(eventId, request.section(), request.rowLabel(), request.seatNumber(), request.price()));
     }
 
     /**

--- a/backend/src/main/java/com/fairtix/inventory/api/SeatController.java
+++ b/backend/src/main/java/com/fairtix/inventory/api/SeatController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.security.PermitAll;
+import jakarta.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -54,7 +55,7 @@ public class SeatController {
     @ResponseStatus(HttpStatus.CREATED)
     public SeatResponse createSeat(
             @PathVariable UUID eventId,
-            @RequestBody CreateSeatRequest request) {
+            @Valid @RequestBody CreateSeatRequest request) {
 
         log.info("Request to create seat for event {} section={} row={} seat={}",
                 eventId, request.section(), request.rowLabel(), request.seatNumber());

--- a/backend/src/main/java/com/fairtix/inventory/application/SeatService.java
+++ b/backend/src/main/java/com/fairtix/inventory/application/SeatService.java
@@ -7,6 +7,7 @@ import com.fairtix.inventory.infrastructure.SeatRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 
@@ -37,14 +38,14 @@ public class SeatService {
    * @return the newly created {@link Seat}
    * @throws IllegalArgumentException if the event is not found
    */
-  public Seat createSeat(UUID eventId, String section, String rowLabel, String seatNumber) {
+  public Seat createSeat(UUID eventId, String section, String rowLabel, String seatNumber, BigDecimal price) {
 
-    log.info("Creating seat for event {} section={} row={} seat={}",
-            eventId, section, rowLabel, seatNumber);
+    log.info("Creating seat for event {} section={} row={} seat={} price={}",
+            eventId, section, rowLabel, seatNumber, price);
 
     var event = eventRepository.findById(eventId)
         .orElseThrow(() -> new IllegalArgumentException("Event not found: " + eventId));
-    return seatRepository.save(new Seat(event, section, rowLabel, seatNumber));
+    return seatRepository.save(new Seat(event, section, rowLabel, seatNumber, price));
   }
 
   /**

--- a/backend/src/main/java/com/fairtix/inventory/domain/Seat.java
+++ b/backend/src/main/java/com/fairtix/inventory/domain/Seat.java
@@ -3,6 +3,7 @@ package com.fairtix.inventory.domain;
 import com.fairtix.events.domain.Event;
 import jakarta.persistence.*;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 @Entity
@@ -29,6 +30,9 @@ public class Seat {
   @Column(nullable = false, name = "seat_number")
   private String seatNumber;
 
+  @Column(nullable = false, precision = 10, scale = 2)
+  private BigDecimal price;
+
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private SeatStatus status = SeatStatus.AVAILABLE;
@@ -36,11 +40,12 @@ public class Seat {
   @Version
   private long version;
 
-  public Seat(Event event, String section, String rowLabel, String seatNumber) {
+  public Seat(Event event, String section, String rowLabel, String seatNumber, BigDecimal price) {
     this.event = event;
     this.section = section;
     this.rowLabel = rowLabel;
     this.seatNumber = seatNumber;
+    this.price = price;
     this.status = SeatStatus.AVAILABLE;
   }
 
@@ -65,6 +70,10 @@ public class Seat {
 
   public String getSeatNumber() {
     return seatNumber;
+  }
+
+  public BigDecimal getPrice() {
+    return price;
   }
 
   public SeatStatus getStatus() {

--- a/backend/src/main/java/com/fairtix/inventory/dto/CreateSeatRequest.java
+++ b/backend/src/main/java/com/fairtix/inventory/dto/CreateSeatRequest.java
@@ -1,6 +1,10 @@
 package com.fairtix.inventory.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
 
 /**
  * Request payload for creating a seat.
@@ -8,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * @param section    the seating section label (e.g. "Floor", "Balcony")
  * @param rowLabel   the row within the section (e.g. "A", "B")
  * @param seatNumber the seat identifier within the row (e.g. "101")
+ * @param price      the ticket price for this seat
  */
 @Schema(description = "Payload for creating a seat in an event's inventory")
 public record CreateSeatRequest(
@@ -16,5 +21,9 @@ public record CreateSeatRequest(
         @Schema(description = "Row within the section", example = "A")
         String rowLabel,
         @Schema(description = "Seat identifier within the row", example = "101")
-        String seatNumber) {
+        String seatNumber,
+        @NotNull
+        @DecimalMin("0.00")
+        @Schema(description = "Ticket price for this seat", example = "49.99")
+        BigDecimal price) {
 }

--- a/backend/src/main/java/com/fairtix/inventory/dto/SeatResponse.java
+++ b/backend/src/main/java/com/fairtix/inventory/dto/SeatResponse.java
@@ -5,6 +5,7 @@ import com.fairtix.inventory.domain.SeatStatus;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 /**
@@ -15,6 +16,7 @@ import java.util.UUID;
  * @param section    the seating section
  * @param rowLabel   the row within the section
  * @param seatNumber the individual seat number
+ * @param price      the ticket price for this seat
  * @param status     the current availability status
  */
 @Schema(description = "Seat details")
@@ -29,6 +31,8 @@ public record SeatResponse(
         String rowLabel,
         @Schema(description = "Seat number", example = "101")
         String seatNumber,
+        @Schema(description = "Ticket price", example = "49.99")
+        BigDecimal price,
         @Schema(description = "Availability status", example = "AVAILABLE")
         SeatStatus status) {
 
@@ -45,6 +49,7 @@ public record SeatResponse(
                 seat.getSection(),
                 seat.getRowLabel(),
                 seat.getSeatNumber(),
+                seat.getPrice(),
                 seat.getStatus());
     }
 }

--- a/backend/src/main/java/com/fairtix/orders/application/OrderService.java
+++ b/backend/src/main/java/com/fairtix/orders/application/OrderService.java
@@ -74,8 +74,11 @@ public class OrderService {
       seatRepository.save(seat);
     }
 
-    // Create the order (MVP: totalAmount = 0, no payment integration)
-    Order order = new Order(user, holdIds, BigDecimal.ZERO, "USD");
+    BigDecimal totalAmount = holds.stream()
+        .map(hold -> hold.getSeat().getPrice())
+        .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+    Order order = new Order(user, holdIds, totalAmount, "USD");
     order = orderRepository.save(order);
 
     // Issue tickets for each hold

--- a/backend/src/main/java/com/fairtix/tickets/application/TicketService.java
+++ b/backend/src/main/java/com/fairtix/tickets/application/TicketService.java
@@ -25,7 +25,8 @@ public class TicketService {
             order,
             order.getUser(),
             hold.getSeat(),
-            hold.getSeat().getEvent()))
+            hold.getSeat().getEvent(),
+            hold.getSeat().getPrice()))
         .toList();
     ticketRepository.saveAll(tickets);
   }

--- a/backend/src/main/java/com/fairtix/tickets/domain/Ticket.java
+++ b/backend/src/main/java/com/fairtix/tickets/domain/Ticket.java
@@ -6,6 +6,7 @@ import com.fairtix.orders.domain.Order;
 import com.fairtix.users.domain.User;
 import jakarta.persistence.*;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -37,6 +38,9 @@ public class Ticket {
   @JoinColumn(name = "event_id", nullable = false)
   private Event event;
 
+  @Column(nullable = false, precision = 10, scale = 2)
+  private BigDecimal price;
+
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private TicketStatus status;
@@ -44,11 +48,12 @@ public class Ticket {
   @Column(name = "issued_at", nullable = false, updatable = false)
   private Instant issuedAt;
 
-  public Ticket(Order order, User user, Seat seat, Event event) {
+  public Ticket(Order order, User user, Seat seat, Event event, BigDecimal price) {
     this.order = order;
     this.user = user;
     this.seat = seat;
     this.event = event;
+    this.price = price;
     this.status = TicketStatus.VALID;
     this.issuedAt = Instant.now();
   }
@@ -74,6 +79,10 @@ public class Ticket {
 
   public Event getEvent() {
     return event;
+  }
+
+  public BigDecimal getPrice() {
+    return price;
   }
 
   public TicketStatus getStatus() {

--- a/backend/src/main/java/com/fairtix/tickets/dto/TicketResponse.java
+++ b/backend/src/main/java/com/fairtix/tickets/dto/TicketResponse.java
@@ -4,6 +4,7 @@ import com.fairtix.tickets.domain.Ticket;
 import com.fairtix.tickets.domain.TicketStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -19,6 +20,7 @@ public record TicketResponse(
         @Schema(description = "Seat section") String seatSection,
         @Schema(description = "Seat row") String seatRow,
         @Schema(description = "Seat number") String seatNumber,
+        @Schema(description = "Ticket price") BigDecimal price,
         @Schema(description = "Ticket holder email") String holderEmail,
         @Schema(description = "Ticket status") TicketStatus status,
         @Schema(description = "When the ticket was issued") Instant issuedAt) {
@@ -35,6 +37,7 @@ public record TicketResponse(
                 ticket.getSeat().getSection(),
                 ticket.getSeat().getRowLabel(),
                 ticket.getSeat().getSeatNumber(),
+                ticket.getPrice(),
                 ticket.getUser().getEmail(),
                 ticket.getStatus(),
                 ticket.getIssuedAt());

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -7,7 +7,13 @@ spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:postgres}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 # JPA / Hibernate
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=validate
+
+# Flyway
+spring.flyway.enabled=true
+spring.flyway.baseline-on-migrate=true
+spring.flyway.locations=classpath:db/migration
+logging.level.org.flywaydb=DEBUG
 logging.level.org.hibernate.SQL=DEBUG
 # ^^ dev only
 spring.jpa.show-sql=true

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -13,7 +13,7 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.flyway.enabled=true
 spring.flyway.baseline-on-migrate=true
 spring.flyway.locations=classpath:db/migration
-logging.level.org.flywaydb=DEBUG
+logging.level.org.flywaydb=INFO
 logging.level.org.hibernate.SQL=DEBUG
 # ^^ dev only
 spring.jpa.show-sql=true

--- a/backend/src/main/resources/db/migration/V1__baseline.sql
+++ b/backend/src/main/resources/db/migration/V1__baseline.sql
@@ -1,0 +1,73 @@
+-- Baseline migration: captures the existing FairTix schema.
+-- Uses IF NOT EXISTS so it is safe to run against databases that already have these tables.
+
+CREATE TABLE IF NOT EXISTS users (
+    id       UUID PRIMARY KEY,
+    email    VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    role     VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS events (
+    id         UUID PRIMARY KEY,
+    title      VARCHAR(500) NOT NULL,
+    venue      VARCHAR(255) NOT NULL,
+    start_time TIMESTAMPTZ  NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS seats (
+    id          UUID PRIMARY KEY,
+    event_id    UUID         NOT NULL REFERENCES events(id),
+    section     VARCHAR(255) NOT NULL,
+    row_label   VARCHAR(255) NOT NULL,
+    seat_number VARCHAR(255) NOT NULL,
+    status      VARCHAR(255) NOT NULL,
+    version     BIGINT       NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_seat_event_id ON seats(event_id);
+CREATE INDEX IF NOT EXISTS idx_seat_status   ON seats(status);
+
+CREATE TABLE IF NOT EXISTS seat_holds (
+    id         UUID PRIMARY KEY,
+    seat_id    UUID        NOT NULL REFERENCES seats(id),
+    owner_id   UUID        NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    status     VARCHAR(255) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_hold_status_expires ON seat_holds(status, expires_at);
+CREATE INDEX IF NOT EXISTS idx_hold_owner_id       ON seat_holds(owner_id);
+
+CREATE TABLE IF NOT EXISTS orders (
+    id           UUID PRIMARY KEY,
+    user_id      UUID           NOT NULL REFERENCES users(id),
+    status       VARCHAR(255)   NOT NULL,
+    total_amount NUMERIC(10, 2) NOT NULL,
+    currency     VARCHAR(3)     NOT NULL,
+    created_at   TIMESTAMPTZ    NOT NULL,
+    updated_at   TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_order_user_id ON orders(user_id);
+CREATE INDEX IF NOT EXISTS idx_order_status  ON orders(status);
+
+CREATE TABLE IF NOT EXISTS order_holds (
+    order_id UUID NOT NULL REFERENCES orders(id),
+    hold_id  UUID NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS tickets (
+    id        UUID PRIMARY KEY,
+    order_id  UUID        NOT NULL REFERENCES orders(id),
+    user_id   UUID        NOT NULL REFERENCES users(id),
+    seat_id   UUID        NOT NULL REFERENCES seats(id),
+    event_id  UUID        NOT NULL REFERENCES events(id),
+    status    VARCHAR(255) NOT NULL,
+    issued_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_ticket_user_id  ON tickets(user_id);
+CREATE INDEX IF NOT EXISTS idx_ticket_order_id ON tickets(order_id);
+CREATE INDEX IF NOT EXISTS idx_ticket_event_id ON tickets(event_id);

--- a/backend/src/main/resources/db/migration/V2__add_seat_price_and_ticket_price.sql
+++ b/backend/src/main/resources/db/migration/V2__add_seat_price_and_ticket_price.sql
@@ -1,0 +1,9 @@
+-- Add price column to seats (backfill existing rows with 0.00 before adding NOT NULL).
+ALTER TABLE seats ADD COLUMN IF NOT EXISTS price NUMERIC(10, 2);
+UPDATE seats SET price = 0.00 WHERE price IS NULL;
+ALTER TABLE seats ALTER COLUMN price SET NOT NULL;
+
+-- Add price snapshot column to tickets (backfill existing rows with 0.00 before adding NOT NULL).
+ALTER TABLE tickets ADD COLUMN IF NOT EXISTS price NUMERIC(10, 2);
+UPDATE tickets SET price = 0.00 WHERE price IS NULL;
+ALTER TABLE tickets ALTER COLUMN price SET NOT NULL;

--- a/backend/src/test/java/com/fairtix/analytics/api/AnalyticsControllerTest.java
+++ b/backend/src/test/java/com/fairtix/analytics/api/AnalyticsControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 
 import static org.hamcrest.Matchers.hasKey;
@@ -47,8 +48,8 @@ class AnalyticsControllerTest {
   void getDashboard_asAdmin_returns200WithExpectedShape() throws Exception {
     // Seed some data so the response has non-empty fields
     var event = eventService.createEvent("Test Show", Instant.parse("2026-08-01T20:00:00Z"), "Arena A");
-    seatService.createSeat(event.getId(), "VIP", "A", "1");
-    seatService.createSeat(event.getId(), "VIP", "A", "2");
+    seatService.createSeat(event.getId(), "VIP", "A", "1", new BigDecimal("75.00"));
+    seatService.createSeat(event.getId(), "VIP", "A", "2", new BigDecimal("75.00"));
 
     mockMvc.perform(get("/api/analytics/dashboard")
             .with(user("admin@test.com").roles("ADMIN"))

--- a/backend/src/test/java/com/fairtix/inventory/api/SeatControllerTest.java
+++ b/backend/src/test/java/com/fairtix/inventory/api/SeatControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -64,7 +65,8 @@ class SeatControllerTest {
         {
           "section":    "Floor",
           "rowLabel":   "A",
-          "seatNumber": "101"
+          "seatNumber": "101",
+          "price":      49.99
         }
         """;
 
@@ -78,6 +80,7 @@ class SeatControllerTest {
         .andExpect(jsonPath("$.section").value("Floor"))
         .andExpect(jsonPath("$.rowLabel").value("A"))
         .andExpect(jsonPath("$.seatNumber").value("101"))
+        .andExpect(jsonPath("$.price").value(49.99))
         .andExpect(jsonPath("$.status").value("AVAILABLE"));
   }
 
@@ -87,7 +90,8 @@ class SeatControllerTest {
         {
           "section":    "Floor",
           "rowLabel":   "A",
-          "seatNumber": "101"
+          "seatNumber": "101",
+          "price":      49.99
         }
         """;
 
@@ -104,7 +108,8 @@ class SeatControllerTest {
         {
           "section":    "Floor",
           "rowLabel":   "A",
-          "seatNumber": "101"
+          "seatNumber": "101",
+          "price":      49.99
         }
         """;
 
@@ -120,7 +125,8 @@ class SeatControllerTest {
         {
           "section":    "Floor",
           "rowLabel":   "A",
-          "seatNumber": "101"
+          "seatNumber": "101",
+          "price":      49.99
         }
         """;
 
@@ -139,9 +145,9 @@ class SeatControllerTest {
 
   @Test
   void getSeats_returnsAllSeats() throws Exception {
-    seatService.createSeat(testEvent.getId(), "Floor", "A", "1");
-    seatService.createSeat(testEvent.getId(), "Floor", "A", "2");
-    seatService.createSeat(testEvent.getId(), "Balcony", "B", "1");
+    seatService.createSeat(testEvent.getId(), "Floor", "A", "1", new BigDecimal("25.00"));
+    seatService.createSeat(testEvent.getId(), "Floor", "A", "2", new BigDecimal("25.00"));
+    seatService.createSeat(testEvent.getId(), "Balcony", "B", "1", new BigDecimal("15.00"));
 
     mockMvc.perform(get("/api/events/{eventId}/seats", testEvent.getId()))
         .andExpect(status().isOk())
@@ -159,8 +165,8 @@ class SeatControllerTest {
 
   @Test
   void getSeats_availableOnly_filtersCorrectly() throws Exception {
-    Seat seat1 = seatService.createSeat(testEvent.getId(), "Floor", "A", "1");
-    seatService.createSeat(testEvent.getId(), "Floor", "A", "2");
+    Seat seat1 = seatService.createSeat(testEvent.getId(), "Floor", "A", "1", new BigDecimal("25.00"));
+    seatService.createSeat(testEvent.getId(), "Floor", "A", "2", new BigDecimal("25.00"));
 
     // Mark seat1 as held to make it unavailable
     // Entity is managed within @Transactional so the change is auto-flushed

--- a/backend/src/test/java/com/fairtix/inventory/application/SeatHoldServiceTest.java
+++ b/backend/src/test/java/com/fairtix/inventory/application/SeatHoldServiceTest.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -42,7 +43,7 @@ class SeatHoldServiceTest {
   void setUp() {
     testEvent = eventRepository.save(
         new Event("Test Event", "Test Venue", Instant.now().plusSeconds(3600)));
-    testSeat = seatRepository.save(new Seat(testEvent, "Floor", "A", "101"));
+    testSeat = seatRepository.save(new Seat(testEvent, "Floor", "A", "101", new BigDecimal("25.00")));
   }
 
   // -------------------------------------------------------------------------
@@ -146,13 +147,13 @@ class SeatHoldServiceTest {
   @Test
   void exceedingMaxActiveHoldsPerHolderThrowsConflict() {
     // Create 2 seats so USER_1 can reach the limit
-    Seat extraSeat = seatRepository.save(new Seat(testEvent, "Floor", "A", "102"));
+    Seat extraSeat = seatRepository.save(new Seat(testEvent, "Floor", "A", "102", new BigDecimal("25.00")));
 
     seatHoldService.createHold(testEvent.getId(), List.of(testSeat.getId()), USER_1, 10);
     seatHoldService.createHold(testEvent.getId(), List.of(extraSeat.getId()), USER_1, 10);
 
     // Third seat — must be blocked by the active-hold limit
-    Seat thirdSeat = seatRepository.save(new Seat(testEvent, "Floor", "A", "103"));
+    Seat thirdSeat = seatRepository.save(new Seat(testEvent, "Floor", "A", "103", new BigDecimal("25.00")));
     assertThatThrownBy(() -> seatHoldService.createHold(
         testEvent.getId(), List.of(thirdSeat.getId()), USER_1, 10))
         .isInstanceOf(SeatHoldConflictException.class)
@@ -161,13 +162,13 @@ class SeatHoldServiceTest {
 
   @Test
   void holdLimitIsPerHolder_otherHolderCanStillHold() {
-    Seat extraSeat = seatRepository.save(new Seat(testEvent, "Floor", "A", "102"));
+    Seat extraSeat = seatRepository.save(new Seat(testEvent, "Floor", "A", "102", new BigDecimal("25.00")));
 
     seatHoldService.createHold(testEvent.getId(), List.of(testSeat.getId()), USER_1, 10);
     seatHoldService.createHold(testEvent.getId(), List.of(extraSeat.getId()), USER_1, 10);
 
     // USER_2 is unaffected by USER_1's limit
-    Seat thirdSeat = seatRepository.save(new Seat(testEvent, "Floor", "A", "103"));
+    Seat thirdSeat = seatRepository.save(new Seat(testEvent, "Floor", "A", "103", new BigDecimal("25.00")));
     List<SeatHold> holds = seatHoldService.createHold(
         testEvent.getId(), List.of(thirdSeat.getId()), USER_2, 10);
     assertThat(holds).hasSize(1);
@@ -182,7 +183,7 @@ class SeatHoldServiceTest {
   void batchHoldLocksSeatsInAnyInputOrder() {
     // Create two seats and request them in reverse UUID order.
     // The service must sort them internally; both must end up HELD.
-    Seat seat2 = seatRepository.save(new Seat(testEvent, "Floor", "A", "102"));
+    Seat seat2 = seatRepository.save(new Seat(testEvent, "Floor", "A", "102", new BigDecimal("25.00")));
 
     // Provide seatIds in descending order (likely reversed from UUID sort)
     UUID id1 = testSeat.getId();
@@ -217,8 +218,8 @@ class SeatHoldServiceTest {
   @Test
   void schedulerExpiresMultipleHoldsInOneBatch() {
     // Create 3 expired holds manually (scheduler page size is 500, so all fit)
-    Seat seat2 = seatRepository.save(new Seat(testEvent, "Floor", "A", "102"));
-    Seat seat3 = seatRepository.save(new Seat(testEvent, "Floor", "A", "103"));
+    Seat seat2 = seatRepository.save(new Seat(testEvent, "Floor", "A", "102", new BigDecimal("25.00")));
+    Seat seat3 = seatRepository.save(new Seat(testEvent, "Floor", "A", "103", new BigDecimal("25.00")));
 
     for (Seat seat : List.of(testSeat, seat2, seat3)) {
       seat.setStatus(SeatStatus.HELD);
@@ -245,7 +246,7 @@ class SeatHoldServiceTest {
 
   @Test
   void listHoldsReturnsOnlyActiveHoldsForHolder() {
-    Seat seat2 = seatRepository.save(new Seat(testEvent, "Floor", "A", "102"));
+    Seat seat2 = seatRepository.save(new Seat(testEvent, "Floor", "A", "102", new BigDecimal("25.00")));
 
     // Two holds for USER_1 (hits the limit of 2 for test props)
     seatHoldService.createHold(testEvent.getId(), List.of(testSeat.getId()), USER_1, 10);

--- a/backend/src/test/java/com/fairtix/orders/api/OrderControllerTest.java
+++ b/backend/src/test/java/com/fairtix/orders/api/OrderControllerTest.java
@@ -21,6 +21,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
@@ -106,7 +107,7 @@ class OrderControllerTest {
   void createOrder_withConfirmedHold_returns201() throws Exception {
     // Set up: event → seat → confirmed hold
     Event event = eventRepository.save(new Event("Test Concert", "Test Venue", Instant.now().plusSeconds(86400)));
-    Seat seat = seatRepository.save(new Seat(event, "A", "1", "101"));
+    Seat seat = seatRepository.save(new Seat(event, "A", "1", "101", new BigDecimal("50.00")));
     seat.setStatus(SeatStatus.BOOKED);
     seat = seatRepository.save(seat);
 
@@ -125,7 +126,8 @@ class OrderControllerTest {
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.id").exists())
         .andExpect(jsonPath("$.userId").value(testUser.getId().toString()))
-        .andExpect(jsonPath("$.status").value("COMPLETED"));
+        .andExpect(jsonPath("$.status").value("COMPLETED"))
+        .andExpect(jsonPath("$.totalAmount").value(50.00));
   }
 
   @Test

--- a/backend/src/test/java/com/fairtix/tickets/api/TicketControllerTest.java
+++ b/backend/src/test/java/com/fairtix/tickets/api/TicketControllerTest.java
@@ -21,6 +21,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -84,7 +85,7 @@ class TicketControllerTest {
   void listTickets_returnsTicketsAfterOrder() throws Exception {
     // Set up: event → seat → confirmed hold → order → tickets
     Event event = eventRepository.save(new Event("Ticket Concert", "Ticket Venue", Instant.now().plusSeconds(86400)));
-    Seat seat = seatRepository.save(new Seat(event, "B", "2", "205"));
+    Seat seat = seatRepository.save(new Seat(event, "B", "2", "205", new BigDecimal("35.00")));
     seat.setStatus(SeatStatus.BOOKED);
     seat = seatRepository.save(seat);
 
@@ -103,6 +104,7 @@ class TicketControllerTest {
         .andExpect(jsonPath("$[0].seatSection").value("B"))
         .andExpect(jsonPath("$[0].seatRow").value("2"))
         .andExpect(jsonPath("$[0].seatNumber").value("205"))
+        .andExpect(jsonPath("$[0].price").value(35.00))
         .andExpect(jsonPath("$[0].status").value("VALID"));
   }
 
@@ -124,7 +126,7 @@ class TicketControllerTest {
 
     // Create order/ticket for testUser
     Event event = eventRepository.save(new Event("Private Show", "Venue", Instant.now().plusSeconds(86400)));
-    Seat seat = seatRepository.save(new Seat(event, "C", "1", "1"));
+    Seat seat = seatRepository.save(new Seat(event, "C", "1", "1", new BigDecimal("35.00")));
     seat.setStatus(SeatStatus.BOOKED);
     seat = seatRepository.save(seat);
 

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -8,6 +8,9 @@ spring.datasource.password=
 
 # JPA / Hibernate
 spring.jpa.hibernate.ddl-auto=create-drop
+
+# Disable Flyway in tests (H2 uses Hibernate ddl-auto instead)
+spring.flyway.enabled=false
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/frontend/webpages/src/admin/components/SeatFormDialog.js
+++ b/frontend/webpages/src/admin/components/SeatFormDialog.js
@@ -13,6 +13,7 @@ function SeatFormDialog({ open, onClose, onSaved, eventId }) {
   const [section, setSection] = useState('');
   const [rowLabel, setRowLabel] = useState('');
   const [seatNumber, setSeatNumber] = useState('');
+  const [price, setPrice] = useState('');
   const [error, setError] = useState('');
   const [saving, setSaving] = useState(false);
 
@@ -21,14 +22,19 @@ function SeatFormDialog({ open, onClose, onSaved, eventId }) {
       setSection('');
       setRowLabel('');
       setSeatNumber('');
+      setPrice('');
       setError('');
     }
   }, [open]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!section.trim() || !rowLabel.trim() || !seatNumber.trim()) {
+    if (!section.trim() || !rowLabel.trim() || !seatNumber.trim() || price === '') {
       setError('All fields are required.');
+      return;
+    }
+    if (isNaN(parseFloat(price)) || parseFloat(price) < 0) {
+      setError('Price must be a non-negative number.');
       return;
     }
 
@@ -39,6 +45,7 @@ function SeatFormDialog({ open, onClose, onSaved, eventId }) {
         section: section.trim(),
         rowLabel: rowLabel.trim(),
         seatNumber: seatNumber.trim(),
+        price: parseFloat(price),
       });
       onSaved();
       onClose();
@@ -79,6 +86,16 @@ function SeatFormDialog({ open, onClose, onSaved, eventId }) {
               required
               fullWidth
               placeholder="e.g. 101, 102"
+            />
+            <TextField
+              label="Price"
+              type="number"
+              value={price}
+              onChange={(e) => setPrice(e.target.value)}
+              required
+              fullWidth
+              placeholder="e.g. 49.99"
+              inputProps={{ min: 0, step: '0.01' }}
             />
           </Box>
         </DialogContent>

--- a/frontend/webpages/src/admin/pages/AdminSeatsPage.js
+++ b/frontend/webpages/src/admin/pages/AdminSeatsPage.js
@@ -120,17 +120,18 @@ function AdminSeatsPage() {
               <TableCell>Section</TableCell>
               <TableCell>Row</TableCell>
               <TableCell>Seat Number</TableCell>
+              <TableCell>Price</TableCell>
               <TableCell>Status</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
             {loading ? (
               <TableRow>
-                <TableCell colSpan={4} align="center">Loading...</TableCell>
+                <TableCell colSpan={5} align="center">Loading...</TableCell>
               </TableRow>
             ) : seats.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={4} align="center">No seats added yet.</TableCell>
+                <TableCell colSpan={5} align="center">No seats added yet.</TableCell>
               </TableRow>
             ) : (
               seats.map((seat) => (
@@ -138,6 +139,7 @@ function AdminSeatsPage() {
                   <TableCell>{seat.section}</TableCell>
                   <TableCell>{seat.rowLabel}</TableCell>
                   <TableCell>{seat.seatNumber}</TableCell>
+                  <TableCell>${seat.price?.toFixed(2) ?? '0.00'}</TableCell>
                   <TableCell>
                     <Chip
                       label={seat.status}

--- a/frontend/webpages/src/pages/EventDetail.js
+++ b/frontend/webpages/src/pages/EventDetail.js
@@ -103,12 +103,20 @@ function EventDetail() {
       ) : (
         Object.entries(sectionGroups).map(([section, sectionSeats]) => (
           <div key={section} className="seat-section-group">
-            <h3>{section}</h3>
+            <h3>{section}{(() => {
+              const prices = sectionSeats.map(s => s.price ?? 0);
+              const min = Math.min(...prices);
+              const max = Math.max(...prices);
+              return min === max
+                ? ` — $${min.toFixed(2)}`
+                : ` — from $${min.toFixed(2)} to $${max.toFixed(2)}`;
+            })()}</h3>
             <table className="seats-table">
               <thead>
                 <tr>
                   <th>Row</th>
                   <th>Seat</th>
+                  <th>Price</th>
                   <th>Status</th>
                 </tr>
               </thead>
@@ -117,6 +125,7 @@ function EventDetail() {
                   <tr key={seat.id}>
                     <td>{seat.rowLabel}</td>
                     <td>{seat.seatNumber}</td>
+                    <td>${(seat.price ?? 0).toFixed(2)}</td>
                     <td>
                       <span className={`seat-status ${seat.status.toLowerCase()}`}>
                         {seat.status}


### PR DESCRIPTION
## Summary
- Introduces Flyway migrations, replacing `ddl-auto=update` with `validate` for safe schema management
- Adds `price` (BigDecimal) field to the Seat entity, set at seat creation by admin
- Snapshots price onto Ticket at issuance for historical accuracy
- OrderService now calculates `totalAmount` from seat prices instead of hardcoding zero
- Frontend: price input in admin seat form, price columns in admin and public seat tables, price ranges in section headers

## Issues Addressed
- Closes #60 — Add pricing model for seats or ticket tiers
- Closes #57 — Introduce migrations

## Test plan
- [x] All 94 backend tests pass (updated constructors + new price assertions)
- [x] Full API flow verified: create seat with price → hold → confirm → order shows correct totalAmount → tickets have snapshotted price
- [ ] Verify admin seat creation dialog shows price field on frontend
- [ ] Verify event detail page shows prices per seat and per-section ranges