### PR TITLE
Add payment simulation, login lockout, and account deletion

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>4.0.1</version>
+    <version>4.0.2</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>com.fairtix</groupId>
@@ -28,6 +28,9 @@
   </scm>
   <properties>
     <java.version>21</java.version>
+    <!-- Override vulnerable transitive dependency versions (Trivy CVE fixes) -->
+    <tomcat.version>11.0.18</tomcat.version>
+    <spring-security.version>7.0.4</spring-security.version>
   </properties>
   <dependencies>
     <dependency>

--- a/backend/src/main/java/com/fairtix/auth/application/AccountLockedException.java
+++ b/backend/src/main/java/com/fairtix/auth/application/AccountLockedException.java
@@ -1,0 +1,15 @@
+package com.fairtix.auth.application;
+
+public class AccountLockedException extends RuntimeException {
+
+  private final long remainingSeconds;
+
+  public AccountLockedException(long remainingSeconds) {
+    super("Too many failed login attempts. Try again in " + remainingSeconds + " seconds.");
+    this.remainingSeconds = remainingSeconds;
+  }
+
+  public long getRemainingSeconds() {
+    return remainingSeconds;
+  }
+}

--- a/backend/src/main/java/com/fairtix/auth/application/AuthService.java
+++ b/backend/src/main/java/com/fairtix/auth/application/AuthService.java
@@ -10,22 +10,35 @@ import com.fairtix.users.dto.LoginRequest;
 import com.fairtix.users.dto.RegisterRequest;
 import com.fairtix.users.infrastructure.UserRepository;
 
+import java.util.regex.Pattern;
+
 @Service
 public class AuthService {
 
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
   private final JwtService jwtService;
+  private final LoginAttemptService loginAttemptService;
+
+  private static final Pattern UPPERCASE = Pattern.compile("[A-Z]");
+  private static final Pattern LOWERCASE = Pattern.compile("[a-z]");
+  private static final Pattern DIGIT = Pattern.compile("[0-9]");
+  private static final Pattern SPECIAL = Pattern.compile("[^a-zA-Z0-9]");
+  private static final int MIN_PASSWORD_LENGTH = 8;
 
   public AuthService(UserRepository userRepository,
       PasswordEncoder passwordEncoder,
-      JwtService jwtService) {
+      JwtService jwtService,
+      LoginAttemptService loginAttemptService) {
     this.userRepository = userRepository;
     this.passwordEncoder = passwordEncoder;
     this.jwtService = jwtService;
+    this.loginAttemptService = loginAttemptService;
   }
 
   public String register(RegisterRequest request) {
+    validatePasswordStrength(request.password());
+
     if (userRepository.findByEmail(request.email()).isPresent()) {
       throw new ResponseStatusException(HttpStatus.CONFLICT, "User already exists");
     }
@@ -43,16 +56,45 @@ public class AuthService {
   }
 
   public String login(LoginRequest request) {
-    User user = userRepository.findByEmail(request.email())
-        .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid credentials"));
+    // Check lockout before anything else
+    if (loginAttemptService.isLocked(request.email())) {
+      long remaining = loginAttemptService.getRemainingLockoutSeconds(request.email());
+      throw new AccountLockedException(remaining);
+    }
 
-    if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+    User user = userRepository.findByEmail(request.email()).orElse(null);
+
+    if (user == null || user.isDeleted()
+        || !passwordEncoder.matches(request.password(), user.getPassword())) {
+      loginAttemptService.recordFailure(request.email());
       throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid credentials");
     }
+
+    // Successful login — reset attempts
+    loginAttemptService.resetAttempts(request.email());
 
     return jwtService.generateToken(
         user.getId(),
         user.getEmail(),
         user.getRole().name());
+  }
+
+  private void validatePasswordStrength(String password) {
+    if (password == null || password.length() < MIN_PASSWORD_LENGTH) {
+      throw new WeakPasswordException(
+          "Password must be at least " + MIN_PASSWORD_LENGTH + " characters long");
+    }
+    if (!UPPERCASE.matcher(password).find()) {
+      throw new WeakPasswordException("Password must contain at least one uppercase letter");
+    }
+    if (!LOWERCASE.matcher(password).find()) {
+      throw new WeakPasswordException("Password must contain at least one lowercase letter");
+    }
+    if (!DIGIT.matcher(password).find()) {
+      throw new WeakPasswordException("Password must contain at least one digit");
+    }
+    if (!SPECIAL.matcher(password).find()) {
+      throw new WeakPasswordException("Password must contain at least one special character");
+    }
   }
 }

--- a/backend/src/main/java/com/fairtix/auth/application/LoginAttemptService.java
+++ b/backend/src/main/java/com/fairtix/auth/application/LoginAttemptService.java
@@ -32,7 +32,9 @@ public class LoginAttemptService {
   public void recordFailure(String email) {
     RAtomicLong counter = redissonClient.getAtomicLong(KEY_PREFIX + email.toLowerCase());
     long current = counter.incrementAndGet();
-    if (current == 1) {
+    if (current == 1 || current >= maxAttempts) {
+      // Set TTL on first failure; refresh it when lockout threshold is reached
+      // so the lockout duration is a full window from the moment of lockout
       counter.expire(lockoutDuration);
     }
   }

--- a/backend/src/main/java/com/fairtix/auth/application/LoginAttemptService.java
+++ b/backend/src/main/java/com/fairtix/auth/application/LoginAttemptService.java
@@ -1,0 +1,53 @@
+package com.fairtix.auth.application;
+
+import org.redisson.api.RAtomicLong;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+public class LoginAttemptService {
+
+  private final RedissonClient redissonClient;
+  private final int maxAttempts;
+  private final Duration lockoutDuration;
+
+  private static final String KEY_PREFIX = "login_attempts:";
+
+  public LoginAttemptService(RedissonClient redissonClient,
+      @Value("${auth.max-login-attempts:5}") int maxAttempts,
+      @Value("${auth.lockout-duration-minutes:15}") int lockoutMinutes) {
+    this.redissonClient = redissonClient;
+    this.maxAttempts = maxAttempts;
+    this.lockoutDuration = Duration.ofMinutes(lockoutMinutes);
+  }
+
+  public boolean isLocked(String email) {
+    RAtomicLong counter = redissonClient.getAtomicLong(KEY_PREFIX + email.toLowerCase());
+    return counter.get() >= maxAttempts;
+  }
+
+  public void recordFailure(String email) {
+    RAtomicLong counter = redissonClient.getAtomicLong(KEY_PREFIX + email.toLowerCase());
+    long current = counter.incrementAndGet();
+    if (current == 1) {
+      counter.expire(lockoutDuration);
+    }
+  }
+
+  public void resetAttempts(String email) {
+    redissonClient.getAtomicLong(KEY_PREFIX + email.toLowerCase()).delete();
+  }
+
+  public long getRemainingLockoutSeconds(String email) {
+    RAtomicLong counter = redissonClient.getAtomicLong(KEY_PREFIX + email.toLowerCase());
+    long ttl = counter.remainTimeToLive();
+    return ttl > 0 ? ttl / 1000 : 0;
+  }
+
+  public int getMaxAttempts() {
+    return maxAttempts;
+  }
+}

--- a/backend/src/main/java/com/fairtix/auth/application/WeakPasswordException.java
+++ b/backend/src/main/java/com/fairtix/auth/application/WeakPasswordException.java
@@ -1,0 +1,8 @@
+package com.fairtix.auth.application;
+
+public class WeakPasswordException extends RuntimeException {
+
+  public WeakPasswordException(String message) {
+    super(message);
+  }
+}

--- a/backend/src/main/java/com/fairtix/config/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/fairtix/config/GlobalExceptionHandler.java
@@ -4,6 +4,10 @@ import com.fairtix.common.ResourceNotFoundException;
 import com.fairtix.inventory.application.SeatHoldConflictException;
 import com.fairtix.inventory.application.SeatHoldNotFoundException;
 import com.fairtix.orders.application.OrderNotFoundException;
+import com.fairtix.auth.application.AccountLockedException;
+import com.fairtix.auth.application.WeakPasswordException;
+import com.fairtix.payments.api.PaymentProcessingException;
+import com.fairtix.payments.application.PaymentFailedException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,6 +107,37 @@ public class GlobalExceptionHandler {
   public ResponseEntity<Map<String, Object>> handleResourceNotFound(
       ResourceNotFoundException ex, HttpServletRequest req) {
     return error(HttpStatus.NOT_FOUND, "RESOURCE_NOT_FOUND", ex.getMessage(), req);
+  }
+
+  @ExceptionHandler(AccountLockedException.class)
+  public ResponseEntity<Map<String, Object>> handleAccountLocked(
+      AccountLockedException ex, HttpServletRequest req) {
+    Map<String, Object> body = Map.of(
+        "status", HttpStatus.TOO_MANY_REQUESTS.value(),
+        "code", "ACCOUNT_LOCKED",
+        "message", ex.getMessage(),
+        "remainingSeconds", ex.getRemainingSeconds(),
+        "path", req.getRequestURI(),
+        "timestamp", Instant.now().toString());
+    return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(body);
+  }
+
+  @ExceptionHandler(WeakPasswordException.class)
+  public ResponseEntity<Map<String, Object>> handleWeakPassword(
+      WeakPasswordException ex, HttpServletRequest req) {
+    return error(HttpStatus.BAD_REQUEST, "WEAK_PASSWORD", ex.getMessage(), req);
+  }
+
+  @ExceptionHandler(PaymentProcessingException.class)
+  public ResponseEntity<Object> handlePaymentProcessing(
+      PaymentProcessingException ex, HttpServletRequest req) {
+    return ResponseEntity.status(HttpStatus.PAYMENT_REQUIRED).body(ex.getPaymentResponse());
+  }
+
+  @ExceptionHandler(PaymentFailedException.class)
+  public ResponseEntity<Map<String, Object>> handlePaymentFailed(
+      PaymentFailedException ex, HttpServletRequest req) {
+    return error(HttpStatus.PAYMENT_REQUIRED, "PAYMENT_FAILED", ex.getMessage(), req);
   }
 
   @ExceptionHandler(DataIntegrityViolationException.class)

--- a/backend/src/main/java/com/fairtix/orders/application/OrderService.java
+++ b/backend/src/main/java/com/fairtix/orders/application/OrderService.java
@@ -17,7 +17,7 @@ import com.fairtix.payments.domain.PaymentStatus;
 import com.fairtix.tickets.application.TicketService;
 import com.fairtix.users.domain.User;
 import com.fairtix.users.infrastructure.UserRepository;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -52,11 +52,33 @@ public class OrderService {
   }
 
   /**
-   * Original order creation (MVP path, no payment). Kept for backwards compatibility.
+   * Original order creation (MVP path, no payment). Always succeeds with $0 total.
    */
   @Transactional
   public Order createOrder(UUID userId, List<UUID> holdIds) {
-    return createOrderWithPayment(userId, holdIds, null);
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+
+    List<SeatHold> holds = validateHolds(userId, holdIds);
+
+    for (SeatHold hold : holds) {
+      Seat seat = hold.getSeat();
+      if (seat.getStatus() == SeatStatus.SOLD) {
+        throw new SeatHoldConflictException(
+            "Seat " + seat.getId() + " has already been sold");
+      }
+      if (seat.getStatus() != SeatStatus.BOOKED) {
+        throw new SeatHoldConflictException(
+            "Seat " + seat.getId() + " is not in BOOKED state (status: " + seat.getStatus() + ")");
+      }
+      seat.setStatus(SeatStatus.SOLD);
+      seatRepository.save(seat);
+    }
+
+    Order order = new Order(user, holdIds, BigDecimal.ZERO, "USD");
+    order = orderRepository.save(order);
+    ticketService.issueTickets(order, holds);
+    return order;
   }
 
   /**
@@ -70,7 +92,7 @@ public class OrderService {
    * 5. On success: mark order COMPLETED, issue tickets
    * 6. On failure/cancel: mark order CANCELLED, rollback seats to BOOKED
    */
-  @Transactional
+  @Transactional(noRollbackFor = PaymentFailedException.class)
   public Order createOrderWithPayment(UUID userId, List<UUID> holdIds,
       PaymentStatus simulatedOutcome) {
 

--- a/backend/src/main/java/com/fairtix/orders/application/OrderService.java
+++ b/backend/src/main/java/com/fairtix/orders/application/OrderService.java
@@ -8,7 +8,12 @@ import com.fairtix.inventory.domain.SeatStatus;
 import com.fairtix.inventory.infrastructure.SeatHoldRepository;
 import com.fairtix.inventory.infrastructure.SeatRepository;
 import com.fairtix.orders.domain.Order;
+import com.fairtix.orders.domain.OrderStatus;
 import com.fairtix.orders.infrastructure.OrderRepository;
+import com.fairtix.payments.application.PaymentFailedException;
+import com.fairtix.payments.application.PaymentSimulationService;
+import com.fairtix.payments.domain.PaymentRecord;
+import com.fairtix.payments.domain.PaymentStatus;
 import com.fairtix.tickets.application.TicketService;
 import com.fairtix.users.domain.User;
 import com.fairtix.users.infrastructure.UserRepository;
@@ -27,39 +32,54 @@ public class OrderService {
   private final SeatRepository seatRepository;
   private final UserRepository userRepository;
   private final TicketService ticketService;
+  private final PaymentSimulationService paymentSimulationService;
+
+  /** Simulated price per seat until a real pricing model is added. */
+  private static final BigDecimal SIMULATED_SEAT_PRICE = new BigDecimal("25.00");
 
   public OrderService(OrderRepository orderRepository,
       SeatHoldRepository seatHoldRepository,
       SeatRepository seatRepository,
       UserRepository userRepository,
-      TicketService ticketService) {
+      TicketService ticketService,
+      PaymentSimulationService paymentSimulationService) {
     this.orderRepository = orderRepository;
     this.seatHoldRepository = seatHoldRepository;
     this.seatRepository = seatRepository;
     this.userRepository = userRepository;
     this.ticketService = ticketService;
+    this.paymentSimulationService = paymentSimulationService;
   }
 
+  /**
+   * Original order creation (MVP path, no payment). Kept for backwards compatibility.
+   */
   @Transactional
   public Order createOrder(UUID userId, List<UUID> holdIds) {
+    return createOrderWithPayment(userId, holdIds, null);
+  }
+
+  /**
+   * Creates an order with simulated payment processing.
+   *
+   * Flow:
+   * 1. Validate holds belong to user and are CONFIRMED
+   * 2. Transition seats BOOKED → SOLD
+   * 3. Create order as PENDING
+   * 4. Process simulated payment
+   * 5. On success: mark order COMPLETED, issue tickets
+   * 6. On failure/cancel: mark order CANCELLED, rollback seats to BOOKED
+   */
+  @Transactional
+  public Order createOrderWithPayment(UUID userId, List<UUID> holdIds,
+      PaymentStatus simulatedOutcome) {
+
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
 
-    // Validate all holds exist, belong to this user, and are CONFIRMED
-    List<SeatHold> holds = holdIds.stream()
-        .map(holdId -> seatHoldRepository.findByIdAndOwnerId(holdId, userId)
-            .orElseThrow(() -> new IllegalArgumentException(
-                "Hold not found or does not belong to you: " + holdId)))
-        .toList();
+    List<SeatHold> holds = validateHolds(userId, holdIds);
 
-    for (SeatHold hold : holds) {
-      if (hold.getStatus() != HoldStatus.CONFIRMED) {
-        throw new IllegalArgumentException(
-            "Hold " + hold.getId() + " is not confirmed (status: " + hold.getStatus() + ")");
-      }
-    }
-
-    // Transition seats from BOOKED → SOLD (guard against double-issue)
+    // Transition seats from BOOKED → SOLD
     for (SeatHold hold : holds) {
       Seat seat = hold.getSeat();
       if (seat.getStatus() == SeatStatus.SOLD) {
@@ -74,14 +94,51 @@ public class OrderService {
       seatRepository.save(seat);
     }
 
-    // Create the order (MVP: totalAmount = 0, no payment integration)
-    Order order = new Order(user, holdIds, BigDecimal.ZERO, "USD");
+    // Calculate total (simulated flat price per seat)
+    BigDecimal totalAmount = SIMULATED_SEAT_PRICE.multiply(BigDecimal.valueOf(holds.size()));
+
+    // Create order as PENDING
+    Order order = new Order(user, holdIds, totalAmount, "USD", OrderStatus.PENDING);
     order = orderRepository.save(order);
 
-    // Issue tickets for each hold
-    ticketService.issueTickets(order, holds);
+    // Process simulated payment
+    PaymentRecord payment = paymentSimulationService.processPayment(
+        order.getId(), userId, totalAmount, "USD", simulatedOutcome);
+
+    if (payment.getStatus() == PaymentStatus.SUCCESS) {
+      order.setStatus(OrderStatus.COMPLETED);
+      orderRepository.save(order);
+      ticketService.issueTickets(order, holds);
+    } else {
+      // Rollback: mark order cancelled and revert seats to BOOKED
+      order.setStatus(OrderStatus.CANCELLED);
+      orderRepository.save(order);
+      for (SeatHold hold : holds) {
+        Seat seat = hold.getSeat();
+        seat.setStatus(SeatStatus.BOOKED);
+        seatRepository.save(seat);
+      }
+      throw new PaymentFailedException(
+          payment.getFailureReason(), payment.getStatus(), payment.getTransactionId());
+    }
 
     return order;
+  }
+
+  private List<SeatHold> validateHolds(UUID userId, List<UUID> holdIds) {
+    List<SeatHold> holds = holdIds.stream()
+        .map(holdId -> seatHoldRepository.findByIdAndOwnerId(holdId, userId)
+            .orElseThrow(() -> new IllegalArgumentException(
+                "Hold not found or does not belong to you: " + holdId)))
+        .toList();
+
+    for (SeatHold hold : holds) {
+      if (hold.getStatus() != HoldStatus.CONFIRMED) {
+        throw new IllegalArgumentException(
+            "Hold " + hold.getId() + " is not confirmed (status: " + hold.getStatus() + ")");
+      }
+    }
+    return holds;
   }
 
   public Order getOrder(UUID orderId, UUID userId) {

--- a/backend/src/main/java/com/fairtix/orders/domain/Order.java
+++ b/backend/src/main/java/com/fairtix/orders/domain/Order.java
@@ -46,11 +46,16 @@ public class Order {
   private Instant updatedAt;
 
   public Order(User user, List<UUID> holdIds, BigDecimal totalAmount, String currency) {
+    this(user, holdIds, totalAmount, currency, OrderStatus.COMPLETED);
+  }
+
+  public Order(User user, List<UUID> holdIds, BigDecimal totalAmount, String currency,
+      OrderStatus status) {
     this.user = user;
     this.holdIds = new ArrayList<>(holdIds);
     this.totalAmount = totalAmount;
     this.currency = currency;
-    this.status = OrderStatus.COMPLETED;
+    this.status = status;
     this.createdAt = Instant.now();
     this.updatedAt = this.createdAt;
   }

--- a/backend/src/main/java/com/fairtix/payments/api/PaymentController.java
+++ b/backend/src/main/java/com/fairtix/payments/api/PaymentController.java
@@ -4,7 +4,6 @@ import com.fairtix.auth.domain.CustomUserPrincipal;
 import com.fairtix.orders.application.OrderService;
 import com.fairtix.orders.domain.Order;
 import com.fairtix.payments.application.PaymentFailedException;
-import com.fairtix.payments.domain.PaymentStatus;
 import com.fairtix.payments.dto.PaymentRequest;
 import com.fairtix.payments.dto.PaymentResponse;
 import com.fairtix.payments.infrastructure.PaymentRecordRepository;
@@ -60,9 +59,7 @@ public class PaymentController {
           .orElseThrow();
 
       throw new PaymentProcessingException(PaymentResponse.from(record,
-          ex.getStatus() == PaymentStatus.CANCELLED
-              ? com.fairtix.orders.domain.OrderStatus.CANCELLED
-              : com.fairtix.orders.domain.OrderStatus.CANCELLED));
+          com.fairtix.orders.domain.OrderStatus.CANCELLED));
     }
   }
 }

--- a/backend/src/main/java/com/fairtix/payments/api/PaymentController.java
+++ b/backend/src/main/java/com/fairtix/payments/api/PaymentController.java
@@ -1,0 +1,68 @@
+package com.fairtix.payments.api;
+
+import com.fairtix.auth.domain.CustomUserPrincipal;
+import com.fairtix.orders.application.OrderService;
+import com.fairtix.orders.domain.Order;
+import com.fairtix.payments.application.PaymentFailedException;
+import com.fairtix.payments.domain.PaymentStatus;
+import com.fairtix.payments.dto.PaymentRequest;
+import com.fairtix.payments.dto.PaymentResponse;
+import com.fairtix.payments.infrastructure.PaymentRecordRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Payments", description = "Simulated payment processing")
+@RestController
+@PreAuthorize("isAuthenticated()")
+public class PaymentController {
+
+  private final OrderService orderService;
+  private final PaymentRecordRepository paymentRecordRepository;
+
+  public PaymentController(OrderService orderService,
+      PaymentRecordRepository paymentRecordRepository) {
+    this.orderService = orderService;
+    this.paymentRecordRepository = paymentRecordRepository;
+  }
+
+  @Operation(summary = "Create order with simulated payment",
+      description = "Validates holds, creates a PENDING order, runs simulated payment. "
+          + "On success the order is COMPLETED and tickets are issued. "
+          + "On failure/cancel the order is CANCELLED and seats are rolled back to BOOKED.")
+  @ApiResponse(responseCode = "201", description = "Payment succeeded, order completed")
+  @ApiResponse(responseCode = "402", description = "Payment failed or cancelled")
+  @ApiResponse(responseCode = "400", description = "Invalid holds")
+  @PostMapping("/api/payments/checkout")
+  @ResponseStatus(HttpStatus.CREATED)
+  public PaymentResponse checkout(
+      @AuthenticationPrincipal CustomUserPrincipal principal,
+      @Valid @RequestBody PaymentRequest request) {
+
+    try {
+      Order order = orderService.createOrderWithPayment(
+          principal.getUserId(), request.holdIds(), request.simulatedOutcome());
+
+      var record = paymentRecordRepository.findByOrderId(order.getId())
+          .orElseThrow();
+
+      return PaymentResponse.from(record, order.getStatus());
+    } catch (PaymentFailedException ex) {
+      // Payment failed — return the failure details with 402
+      var record = paymentRecordRepository.findByTransactionId(ex.getTransactionId())
+          .orElseThrow();
+
+      throw new PaymentProcessingException(PaymentResponse.from(record,
+          ex.getStatus() == PaymentStatus.CANCELLED
+              ? com.fairtix.orders.domain.OrderStatus.CANCELLED
+              : com.fairtix.orders.domain.OrderStatus.CANCELLED));
+    }
+  }
+}

--- a/backend/src/main/java/com/fairtix/payments/api/PaymentProcessingException.java
+++ b/backend/src/main/java/com/fairtix/payments/api/PaymentProcessingException.java
@@ -1,0 +1,17 @@
+package com.fairtix.payments.api;
+
+import com.fairtix.payments.dto.PaymentResponse;
+
+public class PaymentProcessingException extends RuntimeException {
+
+  private final PaymentResponse paymentResponse;
+
+  public PaymentProcessingException(PaymentResponse paymentResponse) {
+    super("Payment processing failed");
+    this.paymentResponse = paymentResponse;
+  }
+
+  public PaymentResponse getPaymentResponse() {
+    return paymentResponse;
+  }
+}

--- a/backend/src/main/java/com/fairtix/payments/application/PaymentFailedException.java
+++ b/backend/src/main/java/com/fairtix/payments/application/PaymentFailedException.java
@@ -1,0 +1,23 @@
+package com.fairtix.payments.application;
+
+import com.fairtix.payments.domain.PaymentStatus;
+
+public class PaymentFailedException extends RuntimeException {
+
+  private final PaymentStatus status;
+  private final String transactionId;
+
+  public PaymentFailedException(String message, PaymentStatus status, String transactionId) {
+    super(message);
+    this.status = status;
+    this.transactionId = transactionId;
+  }
+
+  public PaymentStatus getStatus() {
+    return status;
+  }
+
+  public String getTransactionId() {
+    return transactionId;
+  }
+}

--- a/backend/src/main/java/com/fairtix/payments/application/PaymentSimulationService.java
+++ b/backend/src/main/java/com/fairtix/payments/application/PaymentSimulationService.java
@@ -1,0 +1,50 @@
+package com.fairtix.payments.application;
+
+import com.fairtix.payments.domain.PaymentRecord;
+import com.fairtix.payments.domain.PaymentStatus;
+import com.fairtix.payments.infrastructure.PaymentRecordRepository;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Service
+public class PaymentSimulationService {
+
+  private final PaymentRecordRepository paymentRecordRepository;
+
+  public PaymentSimulationService(PaymentRecordRepository paymentRecordRepository) {
+    this.paymentRecordRepository = paymentRecordRepository;
+  }
+
+  /**
+   * Simulates a payment. If simulatedOutcome is null, randomly picks a result
+   * weighted 80% success, 15% failure, 5% cancelled.
+   */
+  public PaymentRecord processPayment(UUID orderId, UUID userId, BigDecimal amount,
+      String currency, PaymentStatus simulatedOutcome) {
+
+    PaymentStatus outcome = simulatedOutcome != null ? simulatedOutcome : randomOutcome();
+    String transactionId = "sim_" + UUID.randomUUID().toString().replace("-", "");
+
+    String failureReason = null;
+    if (outcome == PaymentStatus.FAILURE) {
+      failureReason = "Simulated payment declined";
+    } else if (outcome == PaymentStatus.CANCELLED) {
+      failureReason = "Payment cancelled by user";
+    }
+
+    PaymentRecord record = new PaymentRecord(
+        orderId, userId, amount, currency, outcome, transactionId, failureReason);
+
+    return paymentRecordRepository.save(record);
+  }
+
+  private PaymentStatus randomOutcome() {
+    int roll = ThreadLocalRandom.current().nextInt(100);
+    if (roll < 80) return PaymentStatus.SUCCESS;
+    if (roll < 95) return PaymentStatus.FAILURE;
+    return PaymentStatus.CANCELLED;
+  }
+}

--- a/backend/src/main/java/com/fairtix/payments/domain/PaymentRecord.java
+++ b/backend/src/main/java/com/fairtix/payments/domain/PaymentRecord.java
@@ -1,0 +1,95 @@
+package com.fairtix.payments.domain;
+
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "payment_records", indexes = {
+    @Index(name = "idx_payment_order_id", columnList = "order_id"),
+    @Index(name = "idx_payment_user_id", columnList = "user_id")
+})
+public class PaymentRecord {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private UUID id;
+
+  @Column(nullable = false, name = "order_id")
+  private UUID orderId;
+
+  @Column(nullable = false, name = "user_id")
+  private UUID userId;
+
+  @Column(nullable = false, precision = 10, scale = 2)
+  private BigDecimal amount;
+
+  @Column(nullable = false, length = 3)
+  private String currency;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private PaymentStatus status;
+
+  @Column(name = "transaction_id", unique = true, nullable = false)
+  private String transactionId;
+
+  @Column(name = "failure_reason")
+  private String failureReason;
+
+  @Column(nullable = false, name = "created_at", updatable = false)
+  private Instant createdAt;
+
+  protected PaymentRecord() {
+  }
+
+  public PaymentRecord(UUID orderId, UUID userId, BigDecimal amount, String currency,
+      PaymentStatus status, String transactionId, String failureReason) {
+    this.orderId = orderId;
+    this.userId = userId;
+    this.amount = amount;
+    this.currency = currency;
+    this.status = status;
+    this.transactionId = transactionId;
+    this.failureReason = failureReason;
+    this.createdAt = Instant.now();
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public UUID getOrderId() {
+    return orderId;
+  }
+
+  public UUID getUserId() {
+    return userId;
+  }
+
+  public BigDecimal getAmount() {
+    return amount;
+  }
+
+  public String getCurrency() {
+    return currency;
+  }
+
+  public PaymentStatus getStatus() {
+    return status;
+  }
+
+  public String getTransactionId() {
+    return transactionId;
+  }
+
+  public String getFailureReason() {
+    return failureReason;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+}

--- a/backend/src/main/java/com/fairtix/payments/domain/PaymentStatus.java
+++ b/backend/src/main/java/com/fairtix/payments/domain/PaymentStatus.java
@@ -1,0 +1,7 @@
+package com.fairtix.payments.domain;
+
+public enum PaymentStatus {
+  SUCCESS,
+  FAILURE,
+  CANCELLED
+}

--- a/backend/src/main/java/com/fairtix/payments/dto/PaymentRequest.java
+++ b/backend/src/main/java/com/fairtix/payments/dto/PaymentRequest.java
@@ -1,0 +1,22 @@
+package com.fairtix.payments.dto;
+
+import com.fairtix.payments.domain.PaymentStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+import java.util.UUID;
+
+@Schema(description = "Payment request for simulated payment processing")
+public record PaymentRequest(
+
+    @Schema(description = "IDs of confirmed holds to pay for",
+        example = "[\"c3d4e5f6-a7b8-9012-cdef-123456789012\"]")
+    @NotEmpty(message = "At least one hold ID is required")
+    List<UUID> holdIds,
+
+    @Schema(description = "Simulated payment outcome (SUCCESS, FAILURE, CANCELLED). "
+        + "Omit or set to null for random outcome.",
+        example = "SUCCESS")
+    PaymentStatus simulatedOutcome) {
+}

--- a/backend/src/main/java/com/fairtix/payments/dto/PaymentResponse.java
+++ b/backend/src/main/java/com/fairtix/payments/dto/PaymentResponse.java
@@ -1,0 +1,34 @@
+package com.fairtix.payments.dto;
+
+import com.fairtix.orders.domain.OrderStatus;
+import com.fairtix.payments.domain.PaymentRecord;
+import com.fairtix.payments.domain.PaymentStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Schema(description = "Payment processing result")
+public record PaymentResponse(
+    @Schema(description = "Order ID") UUID orderId,
+    @Schema(description = "Order status") OrderStatus orderStatus,
+    @Schema(description = "Payment status") PaymentStatus paymentStatus,
+    @Schema(description = "Unique transaction ID") String transactionId,
+    @Schema(description = "Amount charged") BigDecimal amount,
+    @Schema(description = "Currency code") String currency,
+    @Schema(description = "Failure reason if payment failed") String failureReason,
+    @Schema(description = "When the payment was processed") Instant processedAt) {
+
+  public static PaymentResponse from(PaymentRecord record, OrderStatus orderStatus) {
+    return new PaymentResponse(
+        record.getOrderId(),
+        orderStatus,
+        record.getStatus(),
+        record.getTransactionId(),
+        record.getAmount(),
+        record.getCurrency(),
+        record.getFailureReason(),
+        record.getCreatedAt());
+  }
+}

--- a/backend/src/main/java/com/fairtix/payments/infrastructure/PaymentRecordRepository.java
+++ b/backend/src/main/java/com/fairtix/payments/infrastructure/PaymentRecordRepository.java
@@ -1,0 +1,14 @@
+package com.fairtix.payments.infrastructure;
+
+import com.fairtix.payments.domain.PaymentRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PaymentRecordRepository extends JpaRepository<PaymentRecord, UUID> {
+
+  Optional<PaymentRecord> findByOrderId(UUID orderId);
+
+  Optional<PaymentRecord> findByTransactionId(String transactionId);
+}

--- a/backend/src/main/java/com/fairtix/tickets/application/TicketService.java
+++ b/backend/src/main/java/com/fairtix/tickets/application/TicketService.java
@@ -7,6 +7,7 @@ import com.fairtix.tickets.domain.Ticket;
 import com.fairtix.tickets.infrastructure.TicketRepository;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 
@@ -19,13 +20,17 @@ public class TicketService {
     this.ticketRepository = ticketRepository;
   }
 
+  /** Simulated price per seat until a real pricing model is added. */
+  private static final BigDecimal SIMULATED_SEAT_PRICE = new BigDecimal("25.00");
+
   public void issueTickets(Order order, List<SeatHold> holds) {
     List<Ticket> tickets = holds.stream()
         .map(hold -> new Ticket(
             order,
             order.getUser(),
             hold.getSeat(),
-            hold.getSeat().getEvent()))
+            hold.getSeat().getEvent(),
+            SIMULATED_SEAT_PRICE))
         .toList();
     ticketRepository.saveAll(tickets);
   }

--- a/backend/src/main/java/com/fairtix/tickets/domain/Ticket.java
+++ b/backend/src/main/java/com/fairtix/tickets/domain/Ticket.java
@@ -6,6 +6,7 @@ import com.fairtix.orders.domain.Order;
 import com.fairtix.users.domain.User;
 import jakarta.persistence.*;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -44,11 +45,15 @@ public class Ticket {
   @Column(name = "issued_at", nullable = false, updatable = false)
   private Instant issuedAt;
 
-  public Ticket(Order order, User user, Seat seat, Event event) {
+  @Column(nullable = false, precision = 10, scale = 2)
+  private BigDecimal price;
+
+  public Ticket(Order order, User user, Seat seat, Event event, BigDecimal price) {
     this.order = order;
     this.user = user;
     this.seat = seat;
     this.event = event;
+    this.price = price;
     this.status = TicketStatus.VALID;
     this.issuedAt = Instant.now();
   }
@@ -82,6 +87,10 @@ public class Ticket {
 
   public Instant getIssuedAt() {
     return issuedAt;
+  }
+
+  public BigDecimal getPrice() {
+    return price;
   }
 
   public void setStatus(TicketStatus status) {

--- a/backend/src/main/java/com/fairtix/users/api/AdminController.java
+++ b/backend/src/main/java/com/fairtix/users/api/AdminController.java
@@ -2,14 +2,13 @@ package com.fairtix.users.api;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
+import com.fairtix.auth.domain.CustomUserPrincipal;
+import com.fairtix.users.application.UserService;
 import com.fairtix.users.infrastructure.UserRepository;
 import com.fairtix.users.domain.User;
 import com.fairtix.users.domain.Role;
@@ -35,6 +34,7 @@ import java.util.UUID;
 public class AdminController {
 
     private final UserRepository userRepository;
+    private final UserService userService;
 
     /**
      * Returns a paginated list of all users.
@@ -71,5 +71,20 @@ public class AdminController {
 
         user.setRole(Role.ADMIN);
         userRepository.save(user);
+    }
+
+    @Operation(summary = "Delete a user account",
+            description = "Admin-only. Soft-deletes the user, anonymizes PII, and releases all holds. "
+                    + "Admins cannot delete their own account via this endpoint.")
+    @ApiResponse(responseCode = "204", description = "User deleted")
+    @ApiResponse(responseCode = "400", description = "Cannot delete own account")
+    @ApiResponse(responseCode = "404", description = "User not found")
+    @DeleteMapping("/users/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteUser(
+            @AuthenticationPrincipal CustomUserPrincipal principal,
+            @PathVariable UUID id) {
+        userService.adminDeleteAccount(principal.getUserId(), id);
     }
 }

--- a/backend/src/main/java/com/fairtix/users/api/UserController.java
+++ b/backend/src/main/java/com/fairtix/users/api/UserController.java
@@ -1,0 +1,37 @@
+package com.fairtix.users.api;
+
+import com.fairtix.auth.domain.CustomUserPrincipal;
+import com.fairtix.users.application.UserService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Users", description = "User account management")
+@RestController
+@PreAuthorize("isAuthenticated()")
+public class UserController {
+
+  private final UserService userService;
+
+  public UserController(UserService userService) {
+    this.userService = userService;
+  }
+
+  @Operation(summary = "Delete own account",
+      description = "Soft-deletes the authenticated user's account. "
+          + "Releases all active and confirmed holds. Anonymizes user data. "
+          + "Existing orders and tickets are preserved for record-keeping.")
+  @ApiResponse(responseCode = "204", description = "Account deleted")
+  @ApiResponse(responseCode = "404", description = "User not found")
+  @DeleteMapping("/api/users/me")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void deleteOwnAccount(@AuthenticationPrincipal CustomUserPrincipal principal) {
+    userService.deleteAccount(principal.getUserId());
+  }
+}

--- a/backend/src/main/java/com/fairtix/users/application/UserService.java
+++ b/backend/src/main/java/com/fairtix/users/application/UserService.java
@@ -80,13 +80,15 @@ public class UserService {
     }
     seatHoldRepository.saveAll(activeHolds);
 
-    // Release CONFIRMED holds (revert seats to AVAILABLE)
+    // Release CONFIRMED holds — only revert seats that aren't already SOLD
     List<SeatHold> confirmedHolds = seatHoldRepository.findAllByOwnerIdAndStatus(
         userId, HoldStatus.CONFIRMED);
     for (SeatHold hold : confirmedHolds) {
       hold.setStatus(HoldStatus.RELEASED);
-      hold.getSeat().setStatus(SeatStatus.AVAILABLE);
-      seatRepository.save(hold.getSeat());
+      if (hold.getSeat().getStatus() != SeatStatus.SOLD) {
+        hold.getSeat().setStatus(SeatStatus.AVAILABLE);
+        seatRepository.save(hold.getSeat());
+      }
     }
     seatHoldRepository.saveAll(confirmedHolds);
   }

--- a/backend/src/main/java/com/fairtix/users/application/UserService.java
+++ b/backend/src/main/java/com/fairtix/users/application/UserService.java
@@ -1,0 +1,100 @@
+package com.fairtix.users.application;
+
+import com.fairtix.inventory.domain.HoldStatus;
+import com.fairtix.inventory.domain.SeatStatus;
+import com.fairtix.inventory.domain.SeatHold;
+import com.fairtix.inventory.infrastructure.SeatHoldRepository;
+import com.fairtix.inventory.infrastructure.SeatRepository;
+import com.fairtix.users.domain.User;
+import com.fairtix.users.infrastructure.UserRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class UserService {
+
+  private final UserRepository userRepository;
+  private final SeatHoldRepository seatHoldRepository;
+  private final SeatRepository seatRepository;
+
+  public UserService(UserRepository userRepository,
+      SeatHoldRepository seatHoldRepository,
+      SeatRepository seatRepository) {
+    this.userRepository = userRepository;
+    this.seatHoldRepository = seatHoldRepository;
+    this.seatRepository = seatRepository;
+  }
+
+  /**
+   * Soft-deletes a user account by anonymizing PII and releasing active holds.
+   * Preserves referential integrity with orders and tickets.
+   */
+  @Transactional
+  public void deleteAccount(UUID userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+
+    if (user.isDeleted()) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found");
+    }
+
+    releaseUserHolds(userId);
+    anonymizeUser(user);
+  }
+
+  /**
+   * Admin-initiated deletion of any user account.
+   */
+  @Transactional
+  public void adminDeleteAccount(UUID adminId, UUID targetUserId) {
+    if (adminId.equals(targetUserId)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+          "Admins cannot delete their own account via the admin endpoint");
+    }
+
+    User target = userRepository.findById(targetUserId)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+
+    if (target.isDeleted()) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found");
+    }
+
+    releaseUserHolds(targetUserId);
+    anonymizeUser(target);
+  }
+
+  private void releaseUserHolds(UUID userId) {
+    // Release ACTIVE holds
+    List<SeatHold> activeHolds = seatHoldRepository.findAllByOwnerIdAndStatus(
+        userId, HoldStatus.ACTIVE);
+    for (SeatHold hold : activeHolds) {
+      hold.setStatus(HoldStatus.RELEASED);
+      hold.getSeat().setStatus(SeatStatus.AVAILABLE);
+      seatRepository.save(hold.getSeat());
+    }
+    seatHoldRepository.saveAll(activeHolds);
+
+    // Release CONFIRMED holds (revert seats to AVAILABLE)
+    List<SeatHold> confirmedHolds = seatHoldRepository.findAllByOwnerIdAndStatus(
+        userId, HoldStatus.CONFIRMED);
+    for (SeatHold hold : confirmedHolds) {
+      hold.setStatus(HoldStatus.RELEASED);
+      hold.getSeat().setStatus(SeatStatus.AVAILABLE);
+      seatRepository.save(hold.getSeat());
+    }
+    seatHoldRepository.saveAll(confirmedHolds);
+  }
+
+  private void anonymizeUser(User user) {
+    user.setEmail("deleted_" + user.getId() + "@fairtix.local");
+    user.setPassword("DELETED");
+    user.setDeletedAt(Instant.now());
+    userRepository.save(user);
+  }
+}

--- a/backend/src/main/java/com/fairtix/users/domain/User.java
+++ b/backend/src/main/java/com/fairtix/users/domain/User.java
@@ -13,6 +13,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+import java.time.Instant;
+
 @Entity
 @Table(name = "users")
 public class User {
@@ -29,6 +31,9 @@ public class User {
 
   @Enumerated(EnumType.STRING)
   private Role role = Role.USER;
+
+  @Column(name = "deleted_at")
+  private Instant deletedAt;
 
   public UUID getId() {
     return id;
@@ -60,5 +65,17 @@ public class User {
 
   public void setRole(Role role) {
     this.role = role;
+  }
+
+  public Instant getDeletedAt() {
+    return deletedAt;
+  }
+
+  public void setDeletedAt(Instant deletedAt) {
+    this.deletedAt = deletedAt;
+  }
+
+  public boolean isDeleted() {
+    return deletedAt != null;
   }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -24,6 +24,10 @@ holds.cleanup.interval-ms=30000
 holds.max-seats-per-hold=10
 holds.max-active-per-holder=5
 
+# Login Attempt Lockout
+auth.max-login-attempts=5
+auth.lockout-duration-minutes=15
+
 # Logging
 logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} [%X{requestId}] %-5level %logger - %msg%n
 

--- a/backend/src/test/java/com/fairtix/auth/api/AuthControllerTest.java
+++ b/backend/src/test/java/com/fairtix/auth/api/AuthControllerTest.java
@@ -53,7 +53,7 @@ class AuthControllerTest {
     String body = """
         {
           "email":    "newuser@test.com",
-          "password": "password123"
+          "password": "Password123!"
         }
         """;
 
@@ -69,7 +69,7 @@ class AuthControllerTest {
     String body = """
         {
           "email":    "duplicate@test.com",
-          "password": "password123"
+          "password": "Password123!"
         }
         """;
 
@@ -91,7 +91,7 @@ class AuthControllerTest {
     String body = """
         {
           "email":    "jwtcheck@test.com",
-          "password": "password123"
+          "password": "Password123!"
         }
         """;
 
@@ -120,7 +120,7 @@ class AuthControllerTest {
     String registerBody = """
         {
           "email":    "loginuser@test.com",
-          "password": "password123"
+          "password": "Password123!"
         }
         """;
     mockMvc.perform(post("/auth/register")
@@ -132,7 +132,7 @@ class AuthControllerTest {
     String loginBody = """
         {
           "email":    "loginuser@test.com",
-          "password": "password123"
+          "password": "Password123!"
         }
         """;
     mockMvc.perform(post("/auth/login")
@@ -148,7 +148,7 @@ class AuthControllerTest {
     String registerBody = """
         {
           "email":    "badpw@test.com",
-          "password": "password123"
+          "password": "Password123!"
         }
         """;
     mockMvc.perform(post("/auth/register")
@@ -174,7 +174,7 @@ class AuthControllerTest {
     String body = """
         {
           "email":    "nobody@test.com",
-          "password": "password123"
+          "password": "Password123!"
         }
         """;
 

--- a/backend/src/test/java/com/fairtix/auth/api/LoginAttemptTest.java
+++ b/backend/src/test/java/com/fairtix/auth/api/LoginAttemptTest.java
@@ -1,0 +1,169 @@
+package com.fairtix.auth.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Tests for login attempt lockout and password strength validation.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Transactional
+class LoginAttemptTest {
+
+  @Autowired private WebApplicationContext context;
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context)
+        .apply(springSecurity())
+        .build();
+  }
+
+  // -------------------------------------------------------------------------
+  // Password Strength Validation
+  // -------------------------------------------------------------------------
+
+  @Test
+  void register_weakPassword_tooShort_returns400() throws Exception {
+    String body = """
+        { "email": "weak1@test.com", "password": "Ab1!" }
+        """;
+    mockMvc.perform(post("/auth/register")
+            .contentType(MediaType.APPLICATION_JSON).content(body))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("WEAK_PASSWORD"));
+  }
+
+  @Test
+  void register_weakPassword_noUppercase_returns400() throws Exception {
+    String body = """
+        { "email": "weak2@test.com", "password": "abcdefg1!" }
+        """;
+    mockMvc.perform(post("/auth/register")
+            .contentType(MediaType.APPLICATION_JSON).content(body))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("WEAK_PASSWORD"));
+  }
+
+  @Test
+  void register_weakPassword_noLowercase_returns400() throws Exception {
+    String body = """
+        { "email": "weak3@test.com", "password": "ABCDEFG1!" }
+        """;
+    mockMvc.perform(post("/auth/register")
+            .contentType(MediaType.APPLICATION_JSON).content(body))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("WEAK_PASSWORD"));
+  }
+
+  @Test
+  void register_weakPassword_noDigit_returns400() throws Exception {
+    String body = """
+        { "email": "weak4@test.com", "password": "Abcdefgh!" }
+        """;
+    mockMvc.perform(post("/auth/register")
+            .contentType(MediaType.APPLICATION_JSON).content(body))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("WEAK_PASSWORD"));
+  }
+
+  @Test
+  void register_weakPassword_noSpecialChar_returns400() throws Exception {
+    String body = """
+        { "email": "weak5@test.com", "password": "Abcdefg1" }
+        """;
+    mockMvc.perform(post("/auth/register")
+            .contentType(MediaType.APPLICATION_JSON).content(body))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("WEAK_PASSWORD"));
+  }
+
+  @Test
+  void register_strongPassword_succeeds() throws Exception {
+    String body = """
+        { "email": "strong@test.com", "password": "StrongP4ss!" }
+        """;
+    mockMvc.perform(post("/auth/register")
+            .contentType(MediaType.APPLICATION_JSON).content(body))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.token").isNotEmpty());
+  }
+
+  // -------------------------------------------------------------------------
+  // Login Attempt Lockout
+  // -------------------------------------------------------------------------
+
+  @Test
+  void login_lockoutAfterMaxAttempts() throws Exception {
+    // Register a user first
+    String regBody = """
+        { "email": "lockout@test.com", "password": "StrongP4ss!" }
+        """;
+    mockMvc.perform(post("/auth/register")
+            .contentType(MediaType.APPLICATION_JSON).content(regBody))
+        .andExpect(status().isOk());
+
+    // Fail 5 times with wrong password
+    String badLogin = """
+        { "email": "lockout@test.com", "password": "wrongpassword" }
+        """;
+    for (int i = 0; i < 5; i++) {
+      mockMvc.perform(post("/auth/login")
+              .contentType(MediaType.APPLICATION_JSON).content(badLogin))
+          .andExpect(status().isUnauthorized());
+    }
+
+    // 6th attempt should be locked out (429)
+    mockMvc.perform(post("/auth/login")
+            .contentType(MediaType.APPLICATION_JSON).content(badLogin))
+        .andExpect(status().isTooManyRequests())
+        .andExpect(jsonPath("$.code").value("ACCOUNT_LOCKED"))
+        .andExpect(jsonPath("$.remainingSeconds").isNumber());
+  }
+
+  @Test
+  void login_successfulLoginResetsAttempts() throws Exception {
+    // Register
+    String regBody = """
+        { "email": "reset@test.com", "password": "StrongP4ss!" }
+        """;
+    mockMvc.perform(post("/auth/register")
+            .contentType(MediaType.APPLICATION_JSON).content(regBody))
+        .andExpect(status().isOk());
+
+    // Fail 3 times
+    String badLogin = """
+        { "email": "reset@test.com", "password": "wrongpassword" }
+        """;
+    for (int i = 0; i < 3; i++) {
+      mockMvc.perform(post("/auth/login")
+              .contentType(MediaType.APPLICATION_JSON).content(badLogin))
+          .andExpect(status().isUnauthorized());
+    }
+
+    // Successful login resets
+    String goodLogin = """
+        { "email": "reset@test.com", "password": "StrongP4ss!" }
+        """;
+    mockMvc.perform(post("/auth/login")
+            .contentType(MediaType.APPLICATION_JSON).content(goodLogin))
+        .andExpect(status().isOk());
+
+    // Can fail again without being locked
+    mockMvc.perform(post("/auth/login")
+            .contentType(MediaType.APPLICATION_JSON).content(badLogin))
+        .andExpect(status().isUnauthorized());
+  }
+}

--- a/backend/src/test/java/com/fairtix/config/TestRedisConfig.java
+++ b/backend/src/test/java/com/fairtix/config/TestRedisConfig.java
@@ -1,11 +1,15 @@
 package com.fairtix.config;
 
 import org.mockito.Mockito;
+import org.redisson.api.RAtomicLong;
 import org.redisson.api.RRateLimiter;
 import org.redisson.api.RedissonClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -13,19 +17,45 @@ import static org.mockito.Mockito.when;
 /**
  * Replaces the real RedissonClient with a mock for tests,
  * so tests don't need a running Redis instance.
+ *
+ * Supports both rate limiter mocking and atomic long mocking
+ * (used by LoginAttemptService).
  */
 @Configuration
 public class TestRedisConfig {
+
+  private final ConcurrentHashMap<String, AtomicLong> atomicLongs = new ConcurrentHashMap<>();
 
   @Bean
   @Primary
   public RedissonClient redissonClient() {
     RedissonClient mock = Mockito.mock(RedissonClient.class);
+
+    // Rate limiter mock
     RRateLimiter limiter = Mockito.mock(RRateLimiter.class);
     when(mock.getRateLimiter(anyString())).thenReturn(limiter);
     when(limiter.tryAcquire(1)).thenReturn(true);
     when(limiter.isExists()).thenReturn(false);
-    when(limiter.trySetRate(Mockito.any(), Mockito.anyLong(), Mockito.anyLong(), Mockito.any())).thenReturn(true);
+    when(limiter.trySetRate(Mockito.any(), Mockito.anyLong(), Mockito.anyLong(), Mockito.any()))
+        .thenReturn(true);
+
+    // Atomic long mock for login attempt tracking
+    when(mock.getAtomicLong(anyString())).thenAnswer(invocation -> {
+      String key = invocation.getArgument(0);
+      AtomicLong backing = atomicLongs.computeIfAbsent(key, k -> new AtomicLong(0));
+
+      RAtomicLong atomicMock = Mockito.mock(RAtomicLong.class);
+      when(atomicMock.get()).thenAnswer(i -> backing.get());
+      when(atomicMock.incrementAndGet()).thenAnswer(i -> backing.incrementAndGet());
+      when(atomicMock.delete()).thenAnswer(i -> {
+        backing.set(0);
+        return true;
+      });
+      when(atomicMock.remainTimeToLive()).thenReturn(900_000L); // 15 min in ms
+      when(atomicMock.expire(Mockito.any(java.time.Duration.class))).thenReturn(true);
+      return atomicMock;
+    });
+
     return mock;
   }
 }

--- a/backend/src/test/java/com/fairtix/payments/api/PaymentControllerTest.java
+++ b/backend/src/test/java/com/fairtix/payments/api/PaymentControllerTest.java
@@ -1,0 +1,152 @@
+package com.fairtix.payments.api;
+
+import com.fairtix.auth.WithMockPrincipal;
+import com.fairtix.events.domain.Event;
+import com.fairtix.events.infrastructure.EventRepository;
+import com.fairtix.inventory.domain.HoldStatus;
+import com.fairtix.inventory.domain.Seat;
+import com.fairtix.inventory.domain.SeatHold;
+import com.fairtix.inventory.domain.SeatStatus;
+import com.fairtix.inventory.infrastructure.SeatHoldRepository;
+import com.fairtix.inventory.infrastructure.SeatRepository;
+import com.fairtix.users.domain.User;
+import com.fairtix.users.infrastructure.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Transactional
+class PaymentControllerTest {
+
+  @Autowired private WebApplicationContext context;
+  @Autowired private UserRepository userRepository;
+  @Autowired private EventRepository eventRepository;
+  @Autowired private SeatRepository seatRepository;
+  @Autowired private SeatHoldRepository seatHoldRepository;
+  @Autowired private PasswordEncoder passwordEncoder;
+
+  private MockMvc mockMvc;
+  private User user;
+  private SeatHold confirmedHold;
+
+  @BeforeEach
+  void setUp() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context)
+        .apply(springSecurity())
+        .build();
+
+    user = new User();
+    user.setEmail("paytest@test.com");
+    user.setPassword(passwordEncoder.encode("Test1234!"));
+    user = userRepository.save(user);
+
+    Event event = new Event("Test Event", "Test Venue", Instant.now().plusSeconds(86400 * 30));
+    event = eventRepository.save(event);
+
+    Seat seat = new Seat(event, "A", "1", "1");
+    seat.setStatus(SeatStatus.BOOKED);
+    seat = seatRepository.save(seat);
+
+    confirmedHold = new SeatHold(seat, user.getId(), Instant.now().plusSeconds(600));
+    confirmedHold.setStatus(HoldStatus.CONFIRMED);
+    confirmedHold = seatHoldRepository.save(confirmedHold);
+  }
+
+  @Test
+  void checkout_success_returnsCreated() throws Exception {
+    String body = """
+        {
+          "holdIds": ["%s"],
+          "simulatedOutcome": "SUCCESS"
+        }
+        """.formatted(confirmedHold.getId());
+
+    mockMvc.perform(post("/api/payments/checkout")
+            .with(WithMockPrincipal.user(user.getId(), user.getEmail()))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.paymentStatus").value("SUCCESS"))
+        .andExpect(jsonPath("$.orderStatus").value("COMPLETED"))
+        .andExpect(jsonPath("$.transactionId").isNotEmpty())
+        .andExpect(jsonPath("$.amount").value(25.00));
+  }
+
+  @Test
+  void checkout_failure_returns402() throws Exception {
+    String body = """
+        {
+          "holdIds": ["%s"],
+          "simulatedOutcome": "FAILURE"
+        }
+        """.formatted(confirmedHold.getId());
+
+    mockMvc.perform(post("/api/payments/checkout")
+            .with(WithMockPrincipal.user(user.getId(), user.getEmail()))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body))
+        .andExpect(status().isPaymentRequired());
+  }
+
+  @Test
+  void checkout_cancelled_returns402() throws Exception {
+    String body = """
+        {
+          "holdIds": ["%s"],
+          "simulatedOutcome": "CANCELLED"
+        }
+        """.formatted(confirmedHold.getId());
+
+    mockMvc.perform(post("/api/payments/checkout")
+            .with(WithMockPrincipal.user(user.getId(), user.getEmail()))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body))
+        .andExpect(status().isPaymentRequired());
+  }
+
+  @Test
+  void checkout_unauthenticated_returns401or403() throws Exception {
+    String body = """
+        {
+          "holdIds": ["%s"],
+          "simulatedOutcome": "SUCCESS"
+        }
+        """.formatted(confirmedHold.getId());
+
+    mockMvc.perform(post("/api/payments/checkout")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void checkout_emptyHoldIds_returns400() throws Exception {
+    String body = """
+        {
+          "holdIds": [],
+          "simulatedOutcome": "SUCCESS"
+        }
+        """;
+
+    mockMvc.perform(post("/api/payments/checkout")
+            .with(WithMockPrincipal.user(user.getId(), user.getEmail()))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body))
+        .andExpect(status().isBadRequest());
+  }
+}

--- a/backend/src/test/java/com/fairtix/payments/api/PaymentControllerTest.java
+++ b/backend/src/test/java/com/fairtix/payments/api/PaymentControllerTest.java
@@ -58,7 +58,7 @@ class PaymentControllerTest {
     Event event = new Event("Test Event", "Test Venue", Instant.now().plusSeconds(86400 * 30));
     event = eventRepository.save(event);
 
-    Seat seat = new Seat(event, "A", "1", "1");
+    Seat seat = new Seat(event, "A", "1", "1", new java.math.BigDecimal("25.00"));
     seat.setStatus(SeatStatus.BOOKED);
     seat = seatRepository.save(seat);
 

--- a/backend/src/test/java/com/fairtix/users/api/AccountDeletionTest.java
+++ b/backend/src/test/java/com/fairtix/users/api/AccountDeletionTest.java
@@ -1,0 +1,166 @@
+package com.fairtix.users.api;
+
+import com.fairtix.auth.WithMockPrincipal;
+import com.fairtix.events.domain.Event;
+import com.fairtix.events.infrastructure.EventRepository;
+import com.fairtix.inventory.domain.HoldStatus;
+import com.fairtix.inventory.domain.Seat;
+import com.fairtix.inventory.domain.SeatHold;
+import com.fairtix.inventory.domain.SeatStatus;
+import com.fairtix.inventory.infrastructure.SeatHoldRepository;
+import com.fairtix.inventory.infrastructure.SeatRepository;
+import com.fairtix.users.domain.Role;
+import com.fairtix.users.domain.User;
+import com.fairtix.users.infrastructure.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Transactional
+class AccountDeletionTest {
+
+  @Autowired private WebApplicationContext context;
+  @Autowired private UserRepository userRepository;
+  @Autowired private EventRepository eventRepository;
+  @Autowired private SeatRepository seatRepository;
+  @Autowired private SeatHoldRepository seatHoldRepository;
+  @Autowired private PasswordEncoder passwordEncoder;
+
+  private MockMvc mockMvc;
+  private User regularUser;
+  private User adminUser;
+  private Event event;
+
+  @BeforeEach
+  void setUp() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context)
+        .apply(springSecurity())
+        .build();
+
+    regularUser = new User();
+    regularUser.setEmail("deluser@test.com");
+    regularUser.setPassword(passwordEncoder.encode("Test1234!"));
+    regularUser = userRepository.save(regularUser);
+
+    adminUser = new User();
+    adminUser.setEmail("admin@test.com");
+    adminUser.setPassword(passwordEncoder.encode("Admin1234!"));
+    adminUser.setRole(Role.ADMIN);
+    adminUser = userRepository.save(adminUser);
+
+    event = new Event("Test Event", "Test Venue", Instant.now().plusSeconds(86400 * 30));
+    event = eventRepository.save(event);
+  }
+
+  // -------------------------------------------------------------------------
+  // Self-deletion: DELETE /api/users/me
+  // -------------------------------------------------------------------------
+
+  @Test
+  void deleteOwnAccount_success() throws Exception {
+    mockMvc.perform(delete("/api/users/me")
+            .with(WithMockPrincipal.user(regularUser.getId(), regularUser.getEmail())))
+        .andExpect(status().isNoContent());
+
+    User deleted = userRepository.findById(regularUser.getId()).orElseThrow();
+    assertTrue(deleted.isDeleted());
+    assertTrue(deleted.getEmail().startsWith("deleted_"));
+    assertEquals("DELETED", deleted.getPassword());
+  }
+
+  @Test
+  void deleteOwnAccount_releasesActiveHolds() throws Exception {
+    Seat seat = new Seat(event, "A", "1", "1");
+    seat.setStatus(SeatStatus.HELD);
+    seat = seatRepository.save(seat);
+
+    SeatHold hold = new SeatHold(seat, regularUser.getId(), Instant.now().plusSeconds(600));
+    hold = seatHoldRepository.save(hold);
+    UUID holdId = hold.getId();
+    UUID seatId = seat.getId();
+
+    mockMvc.perform(delete("/api/users/me")
+            .with(WithMockPrincipal.user(regularUser.getId(), regularUser.getEmail())))
+        .andExpect(status().isNoContent());
+
+    SeatHold releasedHold = seatHoldRepository.findById(holdId).orElseThrow();
+    assertEquals(HoldStatus.RELEASED, releasedHold.getStatus());
+
+    Seat releasedSeat = seatRepository.findById(seatId).orElseThrow();
+    assertEquals(SeatStatus.AVAILABLE, releasedSeat.getStatus());
+  }
+
+  @Test
+  void deleteOwnAccount_unauthenticated_returns403() throws Exception {
+    mockMvc.perform(delete("/api/users/me"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void deletedUser_cannotLogin() throws Exception {
+    // Delete the account
+    mockMvc.perform(delete("/api/users/me")
+            .with(WithMockPrincipal.user(regularUser.getId(), regularUser.getEmail())))
+        .andExpect(status().isNoContent());
+
+    // Try to login
+    String loginBody = """
+        { "email": "deluser@test.com", "password": "Test1234!" }
+        """;
+    mockMvc.perform(post("/auth/login")
+            .contentType(MediaType.APPLICATION_JSON).content(loginBody))
+        .andExpect(status().isUnauthorized());
+  }
+
+  // -------------------------------------------------------------------------
+  // Admin deletion: DELETE /api/admin/users/{id}
+  // -------------------------------------------------------------------------
+
+  @Test
+  void adminDeleteUser_success() throws Exception {
+    mockMvc.perform(delete("/api/admin/users/" + regularUser.getId())
+            .with(WithMockPrincipal.admin(adminUser.getId(), adminUser.getEmail())))
+        .andExpect(status().isNoContent());
+
+    User deleted = userRepository.findById(regularUser.getId()).orElseThrow();
+    assertTrue(deleted.isDeleted());
+  }
+
+  @Test
+  void adminCannotDeleteSelf() throws Exception {
+    mockMvc.perform(delete("/api/admin/users/" + adminUser.getId())
+            .with(WithMockPrincipal.admin(adminUser.getId(), adminUser.getEmail())))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void nonAdminCannotDeleteOtherUsers() throws Exception {
+    mockMvc.perform(delete("/api/admin/users/" + adminUser.getId())
+            .with(WithMockPrincipal.user(regularUser.getId(), regularUser.getEmail())))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void adminDeleteNonExistentUser_returns404() throws Exception {
+    mockMvc.perform(delete("/api/admin/users/" + UUID.randomUUID())
+            .with(WithMockPrincipal.admin(adminUser.getId(), adminUser.getEmail())))
+        .andExpect(status().isNotFound());
+  }
+}

--- a/backend/src/test/java/com/fairtix/users/api/AccountDeletionTest.java
+++ b/backend/src/test/java/com/fairtix/users/api/AccountDeletionTest.java
@@ -87,7 +87,7 @@ class AccountDeletionTest {
 
   @Test
   void deleteOwnAccount_releasesActiveHolds() throws Exception {
-    Seat seat = new Seat(event, "A", "1", "1");
+    Seat seat = new Seat(event, "A", "1", "1", new java.math.BigDecimal("25.00"));
     seat.setStatus(SeatStatus.HELD);
     seat = seatRepository.save(seat);
 

--- a/frontend/webpages/src/admin/pages/AdminUsersPage.js
+++ b/frontend/webpages/src/admin/pages/AdminUsersPage.js
@@ -13,10 +13,13 @@ import Chip from '@mui/material/Chip';
 import Button from '@mui/material/Button';
 import Alert from '@mui/material/Alert';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
+import DeleteIcon from '@mui/icons-material/Delete';
 import ConfirmDialog from '../components/ConfirmDialog';
 import api from '../../api/client';
+import { useAuth } from '../../auth/useAuth';
 
 function AdminUsersPage() {
+  const { user: currentUser } = useAuth();
   const [users, setUsers] = useState([]);
   const [totalElements, setTotalElements] = useState(0);
   const [page, setPage] = useState(0);
@@ -27,6 +30,9 @@ function AdminUsersPage() {
 
   const [promoteOpen, setPromoteOpen] = useState(false);
   const [promotingUser, setPromotingUser] = useState(null);
+
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deletingUser, setDeletingUser] = useState(null);
 
   const fetchUsers = useCallback(async () => {
     setLoading(true);
@@ -61,6 +67,24 @@ function AdminUsersPage() {
     } catch (err) {
       setError(err.message || 'Failed to promote user.');
       setPromoteOpen(false);
+    }
+  };
+
+  const handleDeleteClick = (user) => {
+    setDeletingUser(user);
+    setDeleteOpen(true);
+  };
+
+  const handleDeleteConfirm = async () => {
+    try {
+      await api.delete(`/api/admin/users/${deletingUser.id}`);
+      setSuccess(`${deletingUser.email} has been deleted.`);
+      setDeleteOpen(false);
+      setDeletingUser(null);
+      fetchUsers();
+    } catch (err) {
+      setError(err.message || 'Failed to delete user.');
+      setDeleteOpen(false);
     }
   };
 
@@ -102,7 +126,7 @@ function AdminUsersPage() {
                       color={user.role === 'ADMIN' ? 'primary' : 'default'}
                     />
                   </TableCell>
-                  <TableCell align="right">
+                  <TableCell align="right" sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
                     {user.role !== 'ADMIN' && (
                       <Button
                         size="small"
@@ -111,6 +135,17 @@ function AdminUsersPage() {
                         onClick={() => handlePromoteClick(user)}
                       >
                         Promote to Admin
+                      </Button>
+                    )}
+                    {user.id !== currentUser.userId && (
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        color="error"
+                        startIcon={<DeleteIcon />}
+                        onClick={() => handleDeleteClick(user)}
+                      >
+                        Delete
                       </Button>
                     )}
                   </TableCell>
@@ -139,6 +174,14 @@ function AdminUsersPage() {
         onConfirm={handlePromoteConfirm}
         title="Promote User"
         message={`Are you sure you want to promote "${promotingUser?.email}" to Admin? This action cannot be undone.`}
+      />
+
+      <ConfirmDialog
+        open={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={handleDeleteConfirm}
+        title="Delete User"
+        message={`Are you sure you want to delete "${deletingUser?.email}"? This action is permanent and cannot be undone.`}
       />
     </Box>
   );

--- a/frontend/webpages/src/api/client.js
+++ b/frontend/webpages/src/api/client.js
@@ -26,9 +26,10 @@ async function apiRequest(path, options = {}) {
     let error;
     try {
       const body = await response.json();
-      error = new Error(body.message || 'Request failed');
+      error = new Error(body.message || body.failureReason || 'Request failed');
       error.status = response.status;
       error.code = body.code;
+      error.body = body;
     } catch {
       error = new Error('Request failed');
       error.status = response.status;

--- a/frontend/webpages/src/pages/Checkout.js
+++ b/frontend/webpages/src/pages/Checkout.js
@@ -69,11 +69,11 @@ function Checkout() {
     fetchConfirmedHolds();
   }, [fetchConfirmedHolds]);
 
+  // Simulated price per seat — matches backend SIMULATED_SEAT_PRICE
+  const SIMULATED_SEAT_PRICE = 25.00;
+
   function calculateTotal() {
-    return holds.reduce((sum, hold) => {
-      const seat = seatMap[hold.seatId];
-      return sum + (seat?.price ?? 0);
-    }, 0);
+    return holds.length * SIMULATED_SEAT_PRICE;
   }
 
   function formatCard(value) {
@@ -183,7 +183,7 @@ function Checkout() {
                   <td>{seat ? seat.section : '—'}</td>
                   <td>{seat ? seat.rowLabel : '—'}</td>
                   <td>{seat ? seat.seatNumber : hold.seatId.slice(0, 8) + '...'}</td>
-                  <td>{seat?.price != null ? `$${seat.price.toFixed(2)}` : '—'}</td>
+                  <td>${SIMULATED_SEAT_PRICE.toFixed(2)}</td>
                 </tr>
               );
             })}

--- a/frontend/webpages/src/pages/Checkout.js
+++ b/frontend/webpages/src/pages/Checkout.js
@@ -13,6 +13,10 @@ function Checkout() {
   const [submitting, setSubmitting] = useState(false);
   const [orderResult, setOrderResult] = useState(null);
 
+  const [cardNumber, setCardNumber] = useState('');
+  const [paymentError, setPaymentError] = useState('');
+  const [paymentState, setPaymentState] = useState('form'); // form | processing | success | failed
+
   const fetchConfirmedHolds = useCallback(async () => {
     const passedHoldIds = location.state?.holdIds || [];
     setError('');
@@ -65,20 +69,60 @@ function Checkout() {
     fetchConfirmedHolds();
   }, [fetchConfirmedHolds]);
 
-  async function handlePlaceOrder() {
-    if (submitting || holds.length === 0) return;
+  function calculateTotal() {
+    return holds.reduce((sum, hold) => {
+      const seat = seatMap[hold.seatId];
+      return sum + (seat?.price ?? 0);
+    }, 0);
+  }
+
+  function formatCard(value) {
+    const digits = value.replace(/\D/g, '').slice(0, 16);
+    return digits.replace(/(\d{4})(?=\d)/g, '$1 ');
+  }
+
+  async function handlePayment(e) {
+    e.preventDefault();
+    const digits = cardNumber.replace(/\s/g, '');
+    if (digits.length < 16) {
+      setPaymentError('Please enter a valid 16-digit card number.');
+      return;
+    }
+
+    setPaymentError('');
+    setPaymentState('processing');
     setSubmitting(true);
-    setError('');
+
+    // Determine simulated outcome based on card number
+    const simulatedOutcome = digits.startsWith('4000') ? 'FAILURE' : 'SUCCESS';
+
     try {
-      const order = await api.post('/api/orders', {
+      const result = await api.post('/api/payments/checkout', {
         holdIds: holds.map((h) => h.id),
+        simulatedOutcome,
       });
-      setOrderResult(order);
+      setOrderResult(result);
+      setPaymentState('success');
     } catch (err) {
-      setError(err.message || 'Failed to place order. Your holds may have expired.');
+      setPaymentState('failed');
+      setPaymentError(
+        err.body?.failureReason
+          || err.message
+          || 'Payment declined. Please check your card details or try a different card.'
+      );
     } finally {
       setSubmitting(false);
     }
+  }
+
+  function handleCancel() {
+    navigate('/my-holds');
+  }
+
+  function handleRetry() {
+    setPaymentState('form');
+    setPaymentError('');
+    setCardNumber('');
   }
 
   if (loading) return <div className="loading">Loading checkout...</div>;
@@ -88,8 +132,8 @@ function Checkout() {
       <div className="checkout">
         <div className="checkout-success">
           <h2>Order Confirmed!</h2>
-          <p>Your order has been placed and tickets have been issued.</p>
-          <p className="checkout-order-id">Order ID: {orderResult.id}</p>
+          <p>Your payment was successful and tickets have been issued.</p>
+          <p className="checkout-order-id">Order ID: {orderResult.orderId || orderResult.id}</p>
           <div className="checkout-success-actions">
             <Link to="/my-tickets" className="checkout-btn-primary">View My Tickets</Link>
             <Link to="/events" className="checkout-btn-secondary">Browse Events</Link>
@@ -112,6 +156,8 @@ function Checkout() {
     );
   }
 
+  const total = calculateTotal();
+
   return (
     <div className="checkout">
       <h2>Checkout</h2>
@@ -126,6 +172,7 @@ function Checkout() {
               <th>Section</th>
               <th>Row</th>
               <th>Seat</th>
+              <th>Price</th>
             </tr>
           </thead>
           <tbody>
@@ -136,6 +183,7 @@ function Checkout() {
                   <td>{seat ? seat.section : '—'}</td>
                   <td>{seat ? seat.rowLabel : '—'}</td>
                   <td>{seat ? seat.seatNumber : hold.seatId.slice(0, 8) + '...'}</td>
+                  <td>{seat?.price != null ? `$${seat.price.toFixed(2)}` : '—'}</td>
                 </tr>
               );
             })}
@@ -143,18 +191,59 @@ function Checkout() {
         </table>
         <div className="checkout-total">
           <span>{holds.length} seat{holds.length > 1 ? 's' : ''}</span>
-          <span className="checkout-price">Free (MVP)</span>
+          <span className="checkout-price">${total.toFixed(2)}</span>
         </div>
       </div>
 
-      <div className="checkout-actions">
-        <button className="checkout-btn-secondary" onClick={() => navigate('/my-holds')} disabled={submitting}>
-          Back
-        </button>
-        <button className="checkout-btn-primary" onClick={handlePlaceOrder} disabled={submitting}>
-          {submitting ? 'Placing Order...' : 'Place Order'}
-        </button>
-      </div>
+      {paymentState === 'processing' && (
+        <div className="checkout-processing">
+          <div className="checkout-spinner" />
+          <p>Processing your payment...</p>
+        </div>
+      )}
+
+      {paymentState === 'failed' && (
+        <div className="checkout-payment-failed">
+          <div className="checkout-error">{paymentError}</div>
+          <div className="checkout-actions">
+            <button className="checkout-btn-secondary" onClick={handleCancel}>
+              Cancel
+            </button>
+            <button className="checkout-btn-primary" onClick={handleRetry}>
+              Try Again
+            </button>
+          </div>
+        </div>
+      )}
+
+      {paymentState === 'form' && (
+        <form className="checkout-payment-form" onSubmit={handlePayment}>
+          <h3>Payment Details</h3>
+          {paymentError && <div className="checkout-error">{paymentError}</div>}
+          <div className="checkout-field">
+            <label htmlFor="cardNumber">Card Number</label>
+            <input
+              id="cardNumber"
+              type="text"
+              placeholder="4242 4242 4242 4242"
+              value={cardNumber}
+              onChange={(e) => setCardNumber(formatCard(e.target.value))}
+              maxLength={19}
+              required
+              autoComplete="off"
+            />
+            <span className="checkout-field-hint">Use 4242... for success, 4000... for decline</span>
+          </div>
+          <div className="checkout-actions">
+            <button type="button" className="checkout-btn-secondary" onClick={handleCancel} disabled={submitting}>
+              Cancel
+            </button>
+            <button type="submit" className="checkout-btn-primary" disabled={submitting}>
+              Pay ${total.toFixed(2)}
+            </button>
+          </div>
+        </form>
+      )}
     </div>
   );
 }

--- a/frontend/webpages/src/pages/Dashboard.js
+++ b/frontend/webpages/src/pages/Dashboard.js
@@ -1,17 +1,85 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useAuth } from '../auth/useAuth';
+import api from '../api/client';
+import { removeToken } from '../auth/tokenUtils';
+import '../styles/Dashboard.css';
 
 function Dashboard() {
-  const { user } = useAuth();
+  const { user, logout } = useAuth();
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [confirmEmail, setConfirmEmail] = useState('');
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState('');
+
+  async function handleDeleteAccount() {
+    if (confirmEmail !== user.email) return;
+    setDeleting(true);
+    setError('');
+    try {
+      await api.delete('/api/users/me');
+      removeToken();
+      logout();
+    } catch (err) {
+      setError(err.message || 'Failed to delete account.');
+      setDeleting(false);
+    }
+  }
 
   return (
-    <div style={{ padding: '2rem' }}>
+    <div className="dashboard">
       <h2>Dashboard</h2>
-      <div style={{ marginTop: '1rem' }}>
+      <div className="dashboard-info">
         <p><strong>Email:</strong> {user.email}</p>
         <p><strong>Role:</strong> {user.role}</p>
         <p><strong>User ID:</strong> {user.userId}</p>
       </div>
+
+      <div className="dashboard-danger-zone">
+        <h3>Danger Zone</h3>
+        <p>Permanently delete your account and all associated data.</p>
+        <button
+          className="dashboard-delete-btn"
+          onClick={() => setShowDeleteDialog(true)}
+        >
+          Delete My Account
+        </button>
+      </div>
+
+      {showDeleteDialog && (
+        <div className="dashboard-overlay" onClick={() => !deleting && setShowDeleteDialog(false)}>
+          <div className="dashboard-dialog" onClick={(e) => e.stopPropagation()}>
+            <h3>Delete Account</h3>
+            <p>This action is <strong>permanent</strong> and cannot be undone. All your data will be removed.</p>
+            <p>Type your email to confirm:</p>
+            <p className="dashboard-dialog-email">{user.email}</p>
+            <input
+              type="email"
+              value={confirmEmail}
+              onChange={(e) => setConfirmEmail(e.target.value)}
+              placeholder="Enter your email"
+              disabled={deleting}
+              autoFocus
+            />
+            {error && <div className="dashboard-dialog-error">{error}</div>}
+            <div className="dashboard-dialog-actions">
+              <button
+                className="dashboard-dialog-cancel"
+                onClick={() => { setShowDeleteDialog(false); setConfirmEmail(''); setError(''); }}
+                disabled={deleting}
+              >
+                Cancel
+              </button>
+              <button
+                className="dashboard-dialog-confirm"
+                onClick={handleDeleteAccount}
+                disabled={confirmEmail !== user.email || deleting}
+              >
+                {deleting ? 'Deleting...' : 'Delete My Account'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/webpages/src/pages/Login.js
+++ b/frontend/webpages/src/pages/Login.js
@@ -57,8 +57,8 @@ function Login() {
       await login(email, password);
       navigate(from, { replace: true });
     } catch (err) {
-      if (err.status === 429 || err.status === 403) {
-        const retryAfter = err.retryAfter || 60;
+      if (err.status === 429) {
+        const retryAfter = err.body?.remainingSeconds || 60;
         startLockoutTimer(retryAfter);
         setError('Account temporarily locked due to too many failed attempts.');
       } else {

--- a/frontend/webpages/src/pages/Login.js
+++ b/frontend/webpages/src/pages/Login.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate, useLocation, Link, Navigate } from 'react-router-dom';
 import { useAuth } from '../auth/useAuth';
 import '../styles/Login.css';
@@ -8,18 +8,48 @@ function Login() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [lockoutSeconds, setLockoutSeconds] = useState(0);
+  const lockoutTimer = useRef(null);
   const { login, user } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
 
   const from = location.state?.from?.pathname || '/dashboard';
 
+  useEffect(() => {
+    return () => {
+      if (lockoutTimer.current) clearInterval(lockoutTimer.current);
+    };
+  }, []);
+
   if (user) {
     return <Navigate to={from} replace />;
   }
 
+  function startLockoutTimer(seconds) {
+    setLockoutSeconds(seconds);
+    if (lockoutTimer.current) clearInterval(lockoutTimer.current);
+    lockoutTimer.current = setInterval(() => {
+      setLockoutSeconds((prev) => {
+        if (prev <= 1) {
+          clearInterval(lockoutTimer.current);
+          lockoutTimer.current = null;
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  }
+
+  function formatTime(totalSeconds) {
+    const m = Math.floor(totalSeconds / 60);
+    const s = totalSeconds % 60;
+    return m > 0 ? `${m}m ${s}s` : `${s}s`;
+  }
+
   async function handleSubmit(e) {
     e.preventDefault();
+    if (lockoutSeconds > 0) return;
     setError('');
     setLoading(true);
 
@@ -27,17 +57,34 @@ function Login() {
       await login(email, password);
       navigate(from, { replace: true });
     } catch (err) {
-      setError(err.message || 'Login failed');
+      if (err.status === 429 || err.status === 403) {
+        const retryAfter = err.retryAfter || 60;
+        startLockoutTimer(retryAfter);
+        setError('Account temporarily locked due to too many failed attempts.');
+      } else {
+        setError(err.message || 'Login failed');
+      }
     } finally {
       setLoading(false);
     }
   }
 
+  const isLocked = lockoutSeconds > 0;
+
   return (
     <div className="login-page">
       <h2>Log In</h2>
       <form onSubmit={handleSubmit} className="login-form">
-        {error && <div className="error-message">{error}</div>}
+        {error && (
+          <div className={`error-message${isLocked ? ' lockout-message' : ''}`}>
+            {error}
+            {isLocked && (
+              <div className="lockout-timer">
+                Try again in {formatTime(lockoutSeconds)}
+              </div>
+            )}
+          </div>
+        )}
         <div className="form-group">
           <label htmlFor="email">Email</label>
           <input
@@ -46,6 +93,7 @@ function Login() {
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
+            disabled={isLocked}
           />
         </div>
         <div className="form-group">
@@ -56,10 +104,11 @@ function Login() {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             required
+            disabled={isLocked}
           />
         </div>
-        <button type="submit" disabled={loading}>
-          {loading ? 'Logging in...' : 'Log In'}
+        <button type="submit" disabled={loading || isLocked}>
+          {loading ? 'Logging in...' : isLocked ? 'Account Locked' : 'Log In'}
         </button>
       </form>
       <p className="form-link">

--- a/frontend/webpages/src/pages/Signup.js
+++ b/frontend/webpages/src/pages/Signup.js
@@ -1,7 +1,15 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { useNavigate, Link, Navigate } from 'react-router-dom';
 import { useAuth } from '../auth/useAuth';
 import '../styles/Login.css';
+
+const PASSWORD_RULES = [
+  { key: 'length', label: 'At least 8 characters', test: (p) => p.length >= 8 },
+  { key: 'upper', label: 'Uppercase letter', test: (p) => /[A-Z]/.test(p) },
+  { key: 'lower', label: 'Lowercase letter', test: (p) => /[a-z]/.test(p) },
+  { key: 'digit', label: 'A digit', test: (p) => /\d/.test(p) },
+  { key: 'special', label: 'Special character', test: (p) => /[^A-Za-z0-9]/.test(p) },
+];
 
 function Signup() {
   const [email, setEmail] = useState('');
@@ -14,6 +22,12 @@ function Signup() {
   const { signup, user } = useAuth();
   const navigate = useNavigate();
 
+  const passwordChecks = useMemo(
+    () => PASSWORD_RULES.map((rule) => ({ ...rule, passed: rule.test(password) })),
+    [password]
+  );
+  const allPasswordRequirementsMet = passwordChecks.every((c) => c.passed);
+
   if (user) {
     return <Navigate to="/dashboard" replace />;
   }
@@ -21,6 +35,11 @@ function Signup() {
   async function handleSubmit(e) {
     e.preventDefault();
     setError('');
+
+    if (!allPasswordRequirementsMet) {
+      setError('Password does not meet all requirements.');
+      return;
+    }
 
     if (password !== confirmPassword) {
       setError('Passwords do not match.');
@@ -94,8 +113,17 @@ function Signup() {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             required
-            minLength={6}
+            minLength={8}
           />
+          {password.length > 0 && (
+            <ul className="password-strength">
+              {passwordChecks.map((check) => (
+                <li key={check.key} className={check.passed ? 'met' : 'unmet'}>
+                  {check.passed ? '\u2713' : '\u2717'} {check.label}
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
         <div className="form-group">
           <label htmlFor="confirmPassword">Confirm password</label>
@@ -107,7 +135,7 @@ function Signup() {
             required
           />
         </div>
-        <button type="submit" disabled={loading}>
+        <button type="submit" disabled={loading || !allPasswordRequirementsMet}>
           {loading ? 'Signing up...' : 'Sign Up'}
         </button>
       </form>

--- a/frontend/webpages/src/styles/Checkout.css
+++ b/frontend/webpages/src/styles/Checkout.css
@@ -153,3 +153,80 @@
   gap: 1rem;
   margin-top: 1.5rem;
 }
+
+/* Payment form */
+.checkout-payment-form {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 1.25rem;
+  background: #fff;
+}
+
+.checkout-payment-form h3 {
+  margin: 0 0 1rem;
+  font-size: 1.05rem;
+}
+
+.checkout-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 1.25rem;
+}
+
+.checkout-field label {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: #333;
+}
+
+.checkout-field input {
+  padding: 0.6rem 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-family: monospace;
+  letter-spacing: 0.05em;
+}
+
+.checkout-field input:focus {
+  outline: none;
+  border-color: #1a73e8;
+  box-shadow: 0 0 0 2px rgba(26, 115, 232, 0.15);
+}
+
+.checkout-field-hint {
+  font-size: 0.75rem;
+  color: #999;
+}
+
+/* Processing state */
+.checkout-processing {
+  text-align: center;
+  padding: 2.5rem 1rem;
+}
+
+.checkout-processing p {
+  margin-top: 1rem;
+  color: #555;
+  font-size: 0.95rem;
+}
+
+.checkout-spinner {
+  width: 36px;
+  height: 36px;
+  border: 3px solid #e0e0e0;
+  border-top-color: #1a73e8;
+  border-radius: 50%;
+  margin: 0 auto;
+  animation: checkout-spin 0.8s linear infinite;
+}
+
+@keyframes checkout-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Failed state */
+.checkout-payment-failed {
+  text-align: center;
+}

--- a/frontend/webpages/src/styles/Dashboard.css
+++ b/frontend/webpages/src/styles/Dashboard.css
@@ -1,0 +1,161 @@
+.dashboard {
+  padding: 2rem;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.dashboard h2 {
+  margin: 0 0 1.5rem;
+}
+
+.dashboard-info {
+  margin-bottom: 2rem;
+}
+
+.dashboard-info p {
+  margin: 0.35rem 0;
+}
+
+/* Danger zone */
+.dashboard-danger-zone {
+  margin-top: 3rem;
+  border: 1px solid #e0b4b4;
+  border-radius: 8px;
+  padding: 1.25rem;
+  background: #fef6f6;
+}
+
+.dashboard-danger-zone h3 {
+  margin: 0 0 0.5rem;
+  color: #c5221f;
+  font-size: 1rem;
+}
+
+.dashboard-danger-zone p {
+  margin: 0 0 1rem;
+  color: #666;
+  font-size: 0.9rem;
+}
+
+.dashboard-delete-btn {
+  background: #d32f2f;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.55rem 1.25rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.dashboard-delete-btn:hover {
+  background: #b71c1c;
+}
+
+/* Confirmation dialog overlay */
+.dashboard-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.dashboard-dialog {
+  background: #fff;
+  border-radius: 10px;
+  padding: 1.75rem;
+  max-width: 420px;
+  width: 90%;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.2);
+}
+
+.dashboard-dialog h3 {
+  margin: 0 0 0.75rem;
+  color: #c5221f;
+}
+
+.dashboard-dialog p {
+  margin: 0 0 0.5rem;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.dashboard-dialog-email {
+  font-family: monospace;
+  font-weight: 600;
+  color: #333 !important;
+  background: #f5f5f5;
+  padding: 0.3rem 0.5rem;
+  border-radius: 4px;
+  display: inline-block;
+}
+
+.dashboard-dialog input {
+  width: 100%;
+  padding: 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.95rem;
+  margin-top: 0.5rem;
+  box-sizing: border-box;
+}
+
+.dashboard-dialog input:focus {
+  outline: none;
+  border-color: #d32f2f;
+  box-shadow: 0 0 0 2px rgba(211, 47, 47, 0.15);
+}
+
+.dashboard-dialog-error {
+  color: #c5221f;
+  background: #fce8e6;
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  margin-top: 0.75rem;
+}
+
+.dashboard-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+.dashboard-dialog-cancel {
+  background: none;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 0.5rem 1.25rem;
+  font-size: 0.9rem;
+  color: #555;
+  cursor: pointer;
+}
+
+.dashboard-dialog-cancel:hover:not(:disabled) {
+  border-color: #999;
+  color: #111;
+}
+
+.dashboard-dialog-confirm {
+  background: #d32f2f;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.5rem 1.25rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.dashboard-dialog-confirm:hover:not(:disabled) {
+  background: #b71c1c;
+}
+
+.dashboard-dialog-confirm:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/frontend/webpages/src/styles/Login.css
+++ b/frontend/webpages/src/styles/Login.css
@@ -61,3 +61,33 @@
   color: #1a1a2e;
   font-weight: bold;
 }
+
+/* Lockout styles */
+.lockout-message {
+  border-left: 3px solid #d32f2f;
+}
+
+.lockout-timer {
+  margin-top: 0.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+/* Password strength indicator */
+.password-strength {
+  list-style: none;
+  padding: 0;
+  margin: 0.4rem 0 0;
+  font-size: 0.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.password-strength .met {
+  color: #2e7d32;
+}
+
+.password-strength .unmet {
+  color: #999;
+}


### PR DESCRIPTION
## Summary
- **Payment Simulation (#19):** Adds `POST /api/payments/checkout` with simulated payment processing (success/failure/cancel flows). Orders start as PENDING, complete or cancel based on outcome. PaymentRecord entity tracks transactions. Frontend uses card-number-based outcome (4242=success, 4000=decline).
- **Login Attempt Lockout (#24):** Tracks failed login attempts per email in Redis. Locks account after 5 failures for 15 minutes. Adds password strength validation on registration (8+ chars, uppercase, lowercase, digit, special char). Frontend shows lockout countdown and real-time strength indicator.
- **Account Deletion (#26):** Users can soft-delete via `DELETE /api/users/me`. Admins can delete any user via `DELETE /api/admin/users/{id}` (cannot self-delete). Anonymizes PII, releases holds, preserves orders/tickets. Frontend adds danger zone dialog and admin delete buttons.

Closes #19
Closes #24
Closes #26

## Test plan
- [ ] Payment: Hold seats → confirm → checkout with 4242 card → order completes
- [ ] Payment: Checkout with 4000 card → decline message, retry/cancel options
- [ ] Login: Enter wrong password 5 times → 6th attempt shows lockout with countdown
- [ ] Login: Successful login after failures resets the counter
- [ ] Signup: Password strength indicator updates in real-time, submit disabled until all rules pass
- [ ] Deletion: Dashboard → Delete My Account → type email → account anonymized, logged out
- [ ] Deletion: Admin users page → delete a user → user soft-deleted
- [ ] Deletion: Admin cannot delete own account
- [ ] Deleted user cannot log in
- [ ] All 115 backend tests pass