### PR TITLE
Deploy config, cookie fix, and ESLint cleanup

### DIFF
--- a/backend/src/main/java/com/fairtix/config/RedisConfig.java
+++ b/backend/src/main/java/com/fairtix/config/RedisConfig.java
@@ -17,12 +17,19 @@ public class RedisConfig {
     @Value("${spring.redis.port:6379}")
     private int redisPort;
 
+    @Value("${spring.redis.password:}")
+    private String redisPassword;
+
     @Bean
     @ConditionalOnMissingBean(RedissonClient.class)
     public RedissonClient redissonClient() {
         Config config = new Config();
-        config.useSingleServer()
+        var server = config.useSingleServer()
               .setAddress("redis://" + redisHost + ":" + redisPort);
+
+        if (redisPassword != null && !redisPassword.isBlank()) {
+            server.setPassword(redisPassword);
+        }
 
         return Redisson.create(config);
     }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -18,6 +18,7 @@ logging.level.org.flywaydb=INFO
 # Redis
 spring.redis.host=${SPRING_REDIS_HOST:localhost}
 spring.redis.port=${SPRING_REDIS_PORT:6379}
+spring.redis.password=${SPRING_REDIS_PASSWORD:}
 
 # Seat Holds
 holds.duration-minutes=10


### PR DESCRIPTION
## Summary
- Add `railway.json` and `netlify.toml` for Railway (backend) and Netlify (frontend) deployment
- Fix `SameSite=None` on auth cookies when `cookieSecure=true` so cross-domain cookies work in prod
- Fix Redis auth: pass `SPRING_REDIS_PASSWORD` to Redisson so backend can connect to Railway Redis
- Fix `netlify.toml` publish path (relative to base dir, not repo root)
- Fix ESLint errors that were failing the Netlify CI build (unused vars, missing deps)

## Test plan
- [ ] `curl https://fairtix-production.up.railway.app/actuator/health` returns `{"status":"UP"}`
- [ ] No CORS errors in browser console on https://fairtix.netlify.app
- [ ] Login sets `fairtix_token` cookie with `SameSite=None; Secure`
- [ ] `GET /auth/me` returns user after login